### PR TITLE
fix(workflows): improve ArgoCD sync reliability with hard refresh and wait

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -122,7 +122,14 @@ jobs:
 
       - name: Sync ArgoCD Application
         run: |
+          # Force refresh to ensure ArgoCD picks up the latest changes
+          argocd app get portfolio-app-prod --hard-refresh --grpc-web --server ${{ secrets.ARGOCD_SERVER }} --auth-token ${{ secrets.ARGOCD_TOKEN }}
+          # Wait a moment for refresh to complete
+          sleep 10
+          # Sync the application
           argocd app sync portfolio-app-prod --grpc-web --server ${{ secrets.ARGOCD_SERVER }} --auth-token ${{ secrets.ARGOCD_TOKEN }}
+          # Wait for sync to complete and verify deployment
+          argocd app wait portfolio-app-prod --timeout 300 --grpc-web --server ${{ secrets.ARGOCD_SERVER }} --auth-token ${{ secrets.ARGOCD_TOKEN }}
 
       - name: Create Tag for Release
         id: create_tag

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -101,7 +101,14 @@ jobs:
 
       - name: Sync ArgoCD Application
         run: |
+          # Force refresh to ensure ArgoCD picks up the latest changes
+          argocd app get portfolio-app-stg --hard-refresh --grpc-web --server ${{ secrets.ARGOCD_SERVER }} --auth-token ${{ secrets.ARGOCD_TOKEN }}
+          # Wait a moment for refresh to complete
+          sleep 10
+          # Sync the application
           argocd app sync portfolio-app-stg --grpc-web --server ${{ secrets.ARGOCD_SERVER }} --auth-token ${{ secrets.ARGOCD_TOKEN }}
+          # Wait for sync to complete and verify deployment
+          argocd app wait portfolio-app-stg --timeout 300 --grpc-web --server ${{ secrets.ARGOCD_SERVER }} --auth-token ${{ secrets.ARGOCD_TOKEN }}
 
       - name: Send Success Message via Telegram
         if: ${{ job.status == 'success'}}

--- a/.github/workflows/deploy-version.yml
+++ b/.github/workflows/deploy-version.yml
@@ -88,7 +88,14 @@ jobs:
 
       - name: Sync ArgoCD Application
         run: |
+          # Force refresh to ensure ArgoCD picks up the latest changes
+          argocd app get ${{ env.APP_NAME }} --hard-refresh --grpc-web --server ${{ secrets.ARGOCD_SERVER }} --auth-token ${{ secrets.ARGOCD_TOKEN }}
+          # Wait a moment for refresh to complete
+          sleep 10
+          # Sync the application
           argocd app sync ${{ env.APP_NAME }} --grpc-web --server ${{ secrets.ARGOCD_SERVER }} --auth-token ${{ secrets.ARGOCD_TOKEN }}
+          # Wait for sync to complete and verify deployment
+          argocd app wait ${{ env.APP_NAME }} --timeout 300 --grpc-web --server ${{ secrets.ARGOCD_SERVER }} --auth-token ${{ secrets.ARGOCD_TOKEN }}
 
       - name: Send Success Message via Telegram
         if: ${{ job.status == 'success'}}


### PR DESCRIPTION
## 🐛 Problem Fixed

During production deployment from v1.5.0 → v1.5.1, ArgoCD showed as `synced` but the deployment wasn't actually updated due to cache issues. The GitHub Action updated the manifest correctly, but ArgoCD didn't detect the change immediately.

**Symptom**: ArgoCD reports successful sync, but pods remain on old version.

## 🔧 Solution

Enhanced the ArgoCD sync process in all workflows to include:

1. **Hard refresh** to clear ArgoCD cache
2. **Sleep 10s** to allow refresh to complete  
3. **Standard sync** to apply changes
4. **Wait with timeout** to verify deployment completion

## 📝 Changes Made

### Updated Workflows:
- `cd.yml` - Production automatic deployment
- `deploy-staging.yml` - Manual staging deployment
- `deploy-version.yml` - Manual version deployment

### Enhanced Sync Process:
```bash
# Before (unreliable)
argocd app sync <app-name>

# After (reliable)  
argocd app get <app-name> --hard-refresh    # Clear cache
sleep 10                                     # Wait for refresh
argocd app sync <app-name>                   # Sync changes  
argocd app wait <app-name> --timeout 300    # Verify completion
```

## ✅ Testing Results

**✅ Production Tested**: After applying these fixes manually:
- v1.5.0 → v1.5.1 deployment completed successfully
- New pod `portfolio-cf9c8df-pmpgb` running with v1.5.1
- ArgoCD status: `Synced` and `Healthy`

## 🎯 Benefits

- **🚀 Reliable deployments**: No more cache-related false positives
- **⏱️ Deployment verification**: Only reports success when pods are ready
- **🔄 Consistent behavior**: All environments use same reliable process
- **📱 Accurate notifications**: Telegram alerts only after actual completion
- **🛡️ Timeout protection**: 5min timeout prevents infinite waits

## 🧪 Impact

- **Zero breaking changes**: Existing workflows still work, just more reliable
- **Production ready**: Based on real issue encountered and resolved
- **Future proof**: Prevents cache issues on all future deployments

## 🔍 Root Cause Analysis

**Issue**: ArgoCD uses Git repository caching for performance. When GitHub Actions update manifest files, ArgoCD may not immediately detect changes, leading to:
- Sync showing as successful
- No actual deployment changes
- False positive deployment status

**Solution**: Force cache refresh ensures ArgoCD sees latest changes before attempting sync.

---

**Ready for review** - This fix is based on real production issue that was manually resolved and tested. ✅