### PR TITLE
ci(staging): unique image tags and sync via values-stg in k3s-apps

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -40,7 +40,8 @@ jobs:
             # Generate staging version with commit SHA
             CURRENT_VERSION=$(cat version.txt)
             COMMIT_SHA=$(git rev-parse --short HEAD)
-            STAGING_VERSION="${CURRENT_VERSION}-stg-${COMMIT_SHA}"
+            RUN_NUMBER="${GITHUB_RUN_NUMBER:-0}"
+            STAGING_VERSION="${CURRENT_VERSION}-stg-${COMMIT_SHA}-${RUN_NUMBER}"
             echo "VERSION=$STAGING_VERSION" >> $GITHUB_ENV
             echo "Generated staging version: $STAGING_VERSION"
           fi
@@ -91,11 +92,13 @@ jobs:
       - name: Update staging k3s manifest with new image version
         run: |
           cd k3s-manifest
-          # Update staging ArgoCD application with new image tag
-          yq e -i '.spec.sources[0].helm.values |= sub("tag: \"[^\"]*\""; "tag: \"" + env(VERSION) + "\"")' ./clusters/dev/portfolio-app.yaml
+          # Update staging values file in chart (source of truth for stg)
+          yq e -i '.image.tag = env(VERSION)' ./apps/portfolio/app/chart/values-stg.yaml
+          # (Optional) ensure inline values are not used anymore
+          yq e -i 'del(.spec.sources[0].helm.values)' ./clusters/dev/portfolio-app.yaml
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
-          git add ./clusters/dev/portfolio-app.yaml
+          git add ./apps/portfolio/app/chart/values-stg.yaml ./clusters/dev/portfolio-app.yaml
           git commit -m "feat(portfolio): update staging image to ${{ env.IMAGE_URL }}"
           git push
 


### PR DESCRIPTION
## Resumo
- Garante tag único no staging: CURRENT_VERSION-stg-<shortSHA>-<GITHUB_RUN_NUMBER>
- Atualiza k3s-apps em apps/portfolio/app/chart/values-stg.yaml
- Simplifica CD: sync via ArgoCD

## Como testar
1. Rodar workflow Deploy to Staging sem version
2. Verificar tag no ECR com sufixo do run number
3. Verificar PR no k3s-apps alterando values-stg.yaml
4. ArgoCD Synced com nova tag

## Commits
- 98fb691 ci(staging): ensure unique image tag with run number and update k3s-apps values-stg.yaml
- e819581 refactor(cd): remove cache invalidation complexity, use only force sync
