### PR TITLE
feat(blog): bilingual public blog wired against rb_management_api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,11 @@ RUN echo "@rblab:registry=https://npm.rodolfodebonis.com.br" > .npmrc && \
     echo "//npm.rodolfodebonis.com.br/:_authToken=${VERDACCIO_TOKEN}" >> .npmrc && \
     echo "registry=https://registry.npmjs.org/" >> .npmrc
 
-# Install dependencies
-RUN npm ci
+# Install dependencies. --legacy-peer-deps tolerates the
+# vite-plugin-checker peer-dep mismatch (it asks for eslint >=9.39 but
+# the project still pins eslint 8.x — pre-existing issue, the eslint
+# bump is queued separately).
+RUN npm ci --legacy-peer-deps
 
 # Remove .npmrc for security
 RUN rm -f .npmrc

--- a/components/MainHeader.vue
+++ b/components/MainHeader.vue
@@ -74,6 +74,7 @@ const links = [
   { label: '.sobre()', href: '#about' },
   { label: '.stacks()', href: '#stacks' },
   { label: '.projetos()', href: '#projects' },
+  { label: '.blog()', href: '#blog' },
   { label: '.xp()', href: '#experience' },
   { label: '.contato()', href: '#contact' },
 ]

--- a/components/blog/BlogArticle.vue
+++ b/components/blog/BlogArticle.vue
@@ -46,10 +46,10 @@
         <div
           class="w-10 h-10 rounded-full bg-[var(--accent)] text-[var(--bg-primary)] flex items-center justify-center font-bold text-sm"
         >
-          RB
+          {{ authorInitials }}
         </div>
         <div class="flex flex-col text-sm">
-          <span class="font-medium text-[var(--text-primary)]">Rodolfo De Bonis</span>
+          <span class="font-medium text-[var(--text-primary)]">{{ authorName }}</span>
           <span class="mono text-xs text-[var(--text-muted)]">
             {{ formattedDate }} · {{ data.reading_time_minutes }} min
             <template v-if="data.post.view_count > 0">
@@ -135,6 +135,19 @@ const { data, error } = await useAsyncData<{
 const translation = computed<PostTranslation | undefined>(() =>
   data.value?.post ? pickTranslation(data.value.post, props.lang) : undefined,
 )
+
+// Author display: snapshotted at publish-time on the API side
+// (`post.author.name`). Empty fallback keeps SSR happy if the API
+// shape ever drifts; the avatar derives initials from the name so a
+// rename in Keycloak shows up the next time the post is republished.
+const authorName = computed(() => data.value?.post?.author?.name ?? '')
+
+const authorInitials = computed(() => {
+  const name = authorName.value.trim()
+  if (!name) return '?'
+  const parts = name.split(/\s+/).slice(0, 2)
+  return parts.map((p) => p.charAt(0).toUpperCase()).join('') || '?'
+})
 
 const canonicalUrl = computed(() => {
   const path =
@@ -224,12 +237,12 @@ useHead({
           inLanguage: props.lang,
           author: {
             '@type': 'Person',
-            name: 'Rodolfo De Bonis',
+            name: post.author?.name || 'Rodolfo De Bonis',
             url: 'https://rodolfodebonis.com.br',
           },
           publisher: {
             '@type': 'Person',
-            name: 'Rodolfo De Bonis',
+            name: post.author?.name || 'Rodolfo De Bonis',
           },
           mainEntityOfPage: {
             '@type': 'WebPage',

--- a/components/blog/BlogArticle.vue
+++ b/components/blog/BlogArticle.vue
@@ -1,0 +1,249 @@
+<template>
+  <article class="section-container py-32 max-w-3xl">
+    <!-- 404 -->
+    <div v-if="error" class="text-center py-24">
+      <p class="mono text-[var(--text-muted)] mb-4">// {{ copy.notFound }}</p>
+      <NuxtLink
+        :to="lang === 'en' ? '/en/blog' : '/blog'"
+        class="inline-flex items-center gap-2 text-[var(--accent)] mono hover:underline"
+      >
+        ← {{ copy.backToBlog }}
+      </NuxtLink>
+    </div>
+
+    <template v-else-if="data?.post">
+      <!-- Breadcrumb / back -->
+      <div class="mb-8 flex items-center gap-2 mono text-sm text-[var(--text-muted)]">
+        <span class="text-[var(--accent)]">❯</span>
+        <span>cd</span>
+        <NuxtLink
+          :to="lang === 'en' ? '/en/blog' : '/blog'"
+          class="text-[var(--text-primary)] hover:text-[var(--accent)] transition-colors"
+        >
+          ~/blog
+        </NuxtLink>
+      </div>
+
+      <!-- Tags -->
+      <div
+        v-if="data.post.tags && data.post.tags.length > 0"
+        class="flex flex-wrap gap-2 mb-6"
+      >
+        <BlogTagPill
+          v-for="tag in data.post.tags"
+          :key="tag.id"
+          :label="tag.slug"
+        />
+      </div>
+
+      <!-- Title -->
+      <h1 class="text-4xl md:text-5xl font-bold tracking-tight leading-[1.15] mb-6">
+        {{ translation?.title }}
+      </h1>
+
+      <!-- Author + meta -->
+      <div class="flex items-center gap-3 mb-10 pb-10 border-b border-[var(--border)]">
+        <div
+          class="w-10 h-10 rounded-full bg-[var(--accent)] text-[var(--bg-primary)] flex items-center justify-center font-bold text-sm"
+        >
+          RB
+        </div>
+        <div class="flex flex-col text-sm">
+          <span class="font-medium text-[var(--text-primary)]">Rodolfo De Bonis</span>
+          <span class="mono text-xs text-[var(--text-muted)]">
+            {{ formattedDate }} · {{ data.reading_time_minutes }} min
+            <template v-if="data.post.view_count > 0">
+              · {{ data.post.view_count }} views
+            </template>
+          </span>
+        </div>
+      </div>
+
+      <!-- Cover -->
+      <img
+        v-if="data.post.cover_image_url"
+        :src="data.post.cover_image_url"
+        :alt="translation?.title ?? ''"
+        class="w-full aspect-[16/9] object-cover rounded-2xl border border-[var(--border)] mb-12"
+      />
+
+      <!-- Body (server-rendered HTML) -->
+      <BlogMarkdownContent :html="data.html" />
+
+      <!-- Share -->
+      <div class="mt-16 pt-8 border-t border-[var(--border)]">
+        <div class="flex items-center justify-between gap-4 flex-wrap">
+          <span class="mono text-xs text-[var(--text-muted)]">// share</span>
+          <BlogShareButtons
+            :url="canonicalUrl"
+            :title="translation?.title ?? ''"
+            :lang="lang"
+          />
+        </div>
+      </div>
+
+      <!-- Back -->
+      <div class="mt-12">
+        <NuxtLink
+          :to="lang === 'en' ? '/en/blog' : '/blog'"
+          class="inline-flex items-center gap-2 text-[var(--accent)] mono text-sm hover:underline"
+        >
+          ← {{ copy.backToBlog }}
+        </NuxtLink>
+      </div>
+    </template>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useAsyncData, useHead, useSeoMeta } from 'nuxt/app'
+import {
+  pickTranslation,
+  useBlog,
+  type Lang,
+  type BlogPost,
+  type PostTranslation,
+} from '~/composables/useBlog'
+
+const props = defineProps<{
+  slug: string
+  lang: Lang
+}>()
+
+const copy = computed(() =>
+  props.lang === 'en'
+    ? { notFound: 'post not found', backToBlog: 'back to blog' }
+    : { notFound: 'post não encontrado', backToBlog: 'voltar para o blog' },
+)
+
+const { data, error } = await useAsyncData<{
+  post: BlogPost
+  html: string
+  reading_time_minutes: number
+}>(
+  `blog-article-${props.lang}-${props.slug}`,
+  () =>
+    $fetch(`/api/blog/render/${props.slug}`, {
+      query: { lang: props.lang },
+    }),
+  {
+    server: true,
+  },
+)
+
+const translation = computed<PostTranslation | undefined>(() =>
+  data.value?.post ? pickTranslation(data.value.post, props.lang) : undefined,
+)
+
+const canonicalUrl = computed(() => {
+  const path =
+    props.lang === 'en' ? `/en/blog/${props.slug}` : `/blog/${props.slug}`
+  return `https://rodolfodebonis.com.br${path}`
+})
+
+const altPath = computed(() => {
+  // Cross-language URL: read the *other* language's translation slug
+  // from the post if present; otherwise omit the alternate.
+  const otherLang: Lang = props.lang === 'en' ? 'pt-BR' : 'en'
+  const otherSlug = data.value?.post?.translations?.find(
+    (t) => t.lang === otherLang,
+  )?.slug
+  if (!otherSlug) return null
+  return otherLang === 'en' ? `/en/blog/${otherSlug}` : `/blog/${otherSlug}`
+})
+
+const formattedDate = computed(() => {
+  const iso = data.value?.post?.published_at ?? data.value?.post?.created_at
+  if (!iso) return ''
+  const d = new Date(iso)
+  return d.toLocaleDateString(props.lang === 'en' ? 'en-US' : 'pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  })
+})
+
+// SEO: per-article title/description/og + JSON-LD Article + hreflang.
+useSeoMeta({
+  title: () => translation.value?.seo_title || translation.value?.title || '',
+  description: () =>
+    translation.value?.seo_description || translation.value?.excerpt || '',
+  ogTitle: () => translation.value?.title || '',
+  ogDescription: () =>
+    translation.value?.seo_description || translation.value?.excerpt || '',
+  ogImage: () => data.value?.post?.cover_image_url || undefined,
+  ogUrl: () => canonicalUrl.value,
+  ogType: 'article',
+  twitterCard: 'summary_large_image',
+})
+
+useHead({
+  htmlAttrs: { lang: props.lang === 'en' ? 'en' : 'pt-BR' },
+  link: () => {
+    const links: Array<{ rel: string; hreflang?: string; href: string }> = [
+      { rel: 'canonical', href: canonicalUrl.value },
+      {
+        rel: 'alternate',
+        hreflang: props.lang === 'en' ? 'en' : 'pt-BR',
+        href: canonicalUrl.value,
+      },
+    ]
+    if (altPath.value) {
+      const alt = `https://rodolfodebonis.com.br${altPath.value}`
+      links.push({
+        rel: 'alternate',
+        hreflang: props.lang === 'en' ? 'pt-BR' : 'en',
+        href: alt,
+      })
+      links.push({
+        rel: 'alternate',
+        hreflang: 'x-default',
+        href: alt,
+      })
+    } else {
+      links.push({ rel: 'alternate', hreflang: 'x-default', href: canonicalUrl.value })
+    }
+    return links
+  },
+  script: () => {
+    if (!data.value?.post || !translation.value) return []
+    const post = data.value.post
+    const t = translation.value
+    return [
+      {
+        type: 'application/ld+json',
+        innerHTML: JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'BlogPosting',
+          headline: t.title,
+          description: t.seo_description || t.excerpt || '',
+          image: post.cover_image_url || undefined,
+          datePublished: post.published_at,
+          dateModified: post.updated_at,
+          inLanguage: props.lang,
+          author: {
+            '@type': 'Person',
+            name: 'Rodolfo De Bonis',
+            url: 'https://rodolfodebonis.com.br',
+          },
+          publisher: {
+            '@type': 'Person',
+            name: 'Rodolfo De Bonis',
+          },
+          mainEntityOfPage: {
+            '@type': 'WebPage',
+            '@id': canonicalUrl.value,
+          },
+          keywords: post.tags?.map((tag) => tag.slug).join(', '),
+        }),
+      },
+    ]
+  },
+})
+
+// Best-effort view tracker (fire-and-forget).
+onMounted(() => {
+  useBlog().registerView(props.slug, props.lang)
+})
+</script>

--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -1,0 +1,100 @@
+<template>
+  <NuxtLink
+    :to="link"
+    class="group block bg-[var(--surface)] border border-[var(--border)] rounded-2xl overflow-hidden hover:border-[var(--accent)]/30 transition-all duration-300 flex flex-col"
+  >
+    <!-- Cover -->
+    <div class="aspect-[16/9] bg-[var(--bg-tertiary)] overflow-hidden">
+      <img
+        v-if="post.cover_image_url"
+        :src="post.cover_image_url"
+        :alt="title"
+        class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+        loading="lazy"
+      />
+      <div
+        v-else
+        class="w-full h-full flex items-center justify-center text-[var(--text-muted)] text-xs mono"
+      >
+        // sem cover
+      </div>
+    </div>
+
+    <!-- Body -->
+    <div class="p-6 flex-1 flex flex-col gap-3">
+      <div v-if="post.tags && post.tags.length > 0" class="flex flex-wrap gap-1.5">
+        <BlogTagPill
+          v-for="tag in post.tags.slice(0, 3)"
+          :key="tag.id"
+          :label="tag.slug"
+        />
+      </div>
+
+      <h3 class="text-lg font-bold text-[var(--text-primary)] group-hover:text-[var(--accent)] transition-colors line-clamp-2">
+        {{ title }}
+      </h3>
+
+      <p
+        v-if="excerpt"
+        class="text-sm text-[var(--text-secondary)] line-clamp-3 flex-1"
+      >
+        {{ excerpt }}
+      </p>
+
+      <!-- Meta -->
+      <div class="flex items-center gap-2 text-xs mono text-[var(--text-muted)] pt-2 border-t border-[var(--border)]">
+        <time :datetime="post.published_at ?? post.created_at">
+          {{ formattedDate }}
+        </time>
+        <span>·</span>
+        <span>{{ post.reading_time_minutes }} min</span>
+        <span v-if="post.view_count > 0">·</span>
+        <span v-if="post.view_count > 0" class="flex items-center gap-1">
+          <span class="material-icons text-[12px]">visibility</span>
+          {{ formatViews(post.view_count) }}
+        </span>
+      </div>
+    </div>
+  </NuxtLink>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { pickTranslation, type BlogPost, type Lang } from '~/composables/useBlog'
+
+const props = defineProps<{
+  post: BlogPost
+  lang?: Lang
+}>()
+
+const lang = computed<Lang>(() => props.lang ?? 'pt-BR')
+
+const translation = computed(() => pickTranslation(props.post, lang.value))
+
+const title = computed(() => translation.value?.title ?? '—')
+const excerpt = computed(() => translation.value?.excerpt ?? '')
+
+// Build the link for the appropriate language. Falls back to slug from
+// any available translation when the requested lang isn't present.
+const link = computed(() => {
+  const slug = translation.value?.slug ?? props.post.translations?.[0]?.slug
+  if (!slug) return '/blog'
+  return lang.value === 'en' ? `/en/blog/${slug}` : `/blog/${slug}`
+})
+
+const formattedDate = computed(() => {
+  const iso = props.post.published_at ?? props.post.created_at
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString(lang.value === 'en' ? 'en-US' : 'pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  })
+})
+
+function formatViews(n: number): string {
+  if (n < 1000) return String(n)
+  return (n / 1000).toFixed(1) + 'k'
+}
+</script>

--- a/components/blog/BlogList.vue
+++ b/components/blog/BlogList.vue
@@ -1,0 +1,186 @@
+<template>
+  <div class="section-container py-32">
+    <!-- Hero -->
+    <header class="mb-12">
+      <div class="flex items-center gap-3 mb-4">
+        <span class="mono text-[var(--accent)] text-sm">04.</span>
+        <h1 class="text-4xl md:text-5xl font-bold tracking-tight">
+          {{ copy.title }}
+        </h1>
+      </div>
+      <p class="text-lg text-[var(--text-secondary)] max-w-2xl">
+        {{ copy.description }}
+      </p>
+    </header>
+
+    <!-- Filters -->
+    <div class="space-y-4 mb-10">
+      <BlogSearchBar v-model="search" :placeholder="copy.searchPlaceholder" :lang="lang" />
+
+      <div v-if="tagsList.length > 0" class="flex flex-wrap gap-2">
+        <button
+          type="button"
+          :class="[
+            'inline-flex items-center px-2.5 py-1 rounded-md text-xs mono transition-colors',
+            !activeTag
+              ? 'bg-[var(--accent-muted)] text-[var(--accent)] border border-[var(--accent)]/40'
+              : 'bg-[var(--bg-secondary)] text-[var(--text-muted)] border border-[var(--border)] hover:border-[var(--accent)]/40 hover:text-[var(--accent)]',
+          ]"
+          @click="activeTag = ''"
+        >
+          #{{ copy.allTag }}
+        </button>
+        <button
+          v-for="tag in tagsList"
+          :key="tag.id"
+          type="button"
+          :class="[
+            'inline-flex items-center px-2.5 py-1 rounded-md text-xs mono transition-colors',
+            activeTag === tag.slug
+              ? 'bg-[var(--accent-muted)] text-[var(--accent)] border border-[var(--accent)]/40'
+              : 'bg-[var(--bg-secondary)] text-[var(--text-muted)] border border-[var(--border)] hover:border-[var(--accent)]/40 hover:text-[var(--accent)]',
+          ]"
+          @click="activeTag = activeTag === tag.slug ? '' : tag.slug"
+        >
+          #{{ tag.slug }}
+          <span v-if="tag.post_count" class="ml-1.5 text-[10px] opacity-70">
+            {{ tag.post_count }}
+          </span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Loading -->
+    <div
+      v-if="pending"
+      class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+    >
+      <div
+        v-for="n in 6"
+        :key="n"
+        class="aspect-[4/5] rounded-2xl border border-[var(--border)] bg-[var(--surface)] animate-pulse"
+      ></div>
+    </div>
+
+    <!-- Empty -->
+    <div
+      v-else-if="!data || data.items.length === 0"
+      class="text-center py-24 border border-[var(--border)] rounded-2xl bg-[var(--surface)]"
+    >
+      <p class="text-[var(--text-muted)] mono">// {{ copy.empty }}</p>
+    </div>
+
+    <!-- Cards grid -->
+    <div
+      v-else
+      class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+    >
+      <BlogCard
+        v-for="post in data.items"
+        :key="post.id"
+        :post="post"
+        :lang="lang"
+      />
+    </div>
+
+    <!-- Pagination — minimal: prev/next + page count -->
+    <div
+      v-if="data && data.total > data.page_size"
+      class="flex items-center justify-center gap-3 mt-12 mono text-sm text-[var(--text-muted)]"
+    >
+      <button
+        type="button"
+        class="px-3 py-1.5 rounded-md border border-[var(--border)] disabled:opacity-40 hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
+        :disabled="page <= 1"
+        @click="page = Math.max(1, page - 1)"
+      >
+        ‹
+      </button>
+      <span>
+        // page {{ page }} of {{ Math.max(1, Math.ceil(data.total / data.page_size)) }}
+      </span>
+      <button
+        type="button"
+        class="px-3 py-1.5 rounded-md border border-[var(--border)] disabled:opacity-40 hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
+        :disabled="page * data.page_size >= data.total"
+        @click="page = page + 1"
+      >
+        ›
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useAsyncData } from 'nuxt/app'
+import { useBlog, type Lang, type BlogListResponse } from '~/composables/useBlog'
+
+const props = defineProps<{
+  lang: Lang
+}>()
+
+const search = ref('')
+const activeTag = ref('')
+const page = ref(1)
+
+const copy = computed(() => {
+  if (props.lang === 'en') {
+    return {
+      title: 'Technical notes, postmortems, experiments.',
+      description:
+        'Articles on Go, observability, multi-tenancy, infrastructure — everything I learn building production systems.',
+      searchPlaceholder: 'grep "term" ./posts',
+      allTag: 'all',
+      empty: 'no posts found',
+    }
+  }
+  return {
+    title: 'Notas técnicas, postmortems, experimentos.',
+    description:
+      'Artigos sobre Go, observabilidade, multi-tenancy, infraestrutura — tudo que aprendo construindo sistemas em produção.',
+    searchPlaceholder: 'grep "termo" ./posts',
+    allTag: 'todos',
+    empty: 'nenhum post encontrado',
+  }
+})
+
+// Reset page when filters change so the user always lands on page 1
+// of a refreshed result set.
+watch([search, activeTag], () => {
+  page.value = 1
+})
+
+const filterKey = computed(
+  () => `blog-list-${props.lang}-${search.value}-${activeTag.value}-${page.value}`,
+)
+
+const { data, pending } = await useAsyncData<BlogListResponse>(
+  filterKey,
+  () =>
+    useBlog().getList({
+      lang: props.lang,
+      q: search.value || undefined,
+      tag: activeTag.value || undefined,
+      page: page.value,
+      per_page: 9,
+    }),
+  {
+    server: true,
+    watch: [search, activeTag, page],
+    default: () => ({ items: [], page: 1, page_size: 9, total: 0 }),
+  },
+)
+
+// Tags list — fetched once, used for filter chips. Errors hide the
+// chips silently rather than breaking the page.
+const { data: tagsData } = await useAsyncData(
+  `blog-tags-${props.lang}`,
+  () => useBlog().getTags(),
+  {
+    server: true,
+    default: () => [],
+  },
+)
+const tagsList = computed(() => tagsData.value ?? [])
+</script>

--- a/components/blog/BlogSearchBar.vue
+++ b/components/blog/BlogSearchBar.vue
@@ -1,0 +1,44 @@
+<template>
+  <div
+    class="flex items-center gap-3 px-4 py-3 rounded-lg bg-[var(--surface)] border border-[var(--border)] focus-within:border-[var(--accent)] transition-colors"
+  >
+    <span class="text-[var(--accent)] mono">❯</span>
+    <input
+      :value="modelValue"
+      :placeholder="placeholder"
+      type="search"
+      class="flex-1 bg-transparent outline-none mono text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
+      :aria-label="placeholder"
+      @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+    />
+    <button
+      v-if="modelValue"
+      type="button"
+      class="text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors"
+      :aria-label="lang === 'en' ? 'Clear search' : 'Limpar busca'"
+      @click="$emit('update:modelValue', '')"
+    >
+      <span class="material-icons text-base">close</span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Lang } from '~/composables/useBlog'
+
+withDefaults(
+  defineProps<{
+    modelValue: string
+    placeholder?: string
+    lang?: Lang
+  }>(),
+  {
+    placeholder: 'grep -r "termo" ./posts',
+    lang: 'pt-BR',
+  },
+)
+
+defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+</script>

--- a/components/blog/BlogShareButtons.vue
+++ b/components/blog/BlogShareButtons.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="flex items-center gap-2">
+    <a
+      :href="`https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-[var(--border)] text-xs mono text-[var(--text-muted)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
+      :aria-label="lang === 'en' ? 'Share on Twitter/X' : 'Compartilhar no Twitter/X'"
+    >
+      <span class="material-icons text-sm">share</span>
+      Twitter / X
+    </a>
+    <a
+      :href="`https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-[var(--border)] text-xs mono text-[var(--text-muted)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
+      :aria-label="lang === 'en' ? 'Share on LinkedIn' : 'Compartilhar no LinkedIn'"
+    >
+      <span class="material-icons text-sm">share</span>
+      LinkedIn
+    </a>
+    <button
+      type="button"
+      class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-[var(--border)] text-xs mono text-[var(--text-muted)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
+      :aria-label="lang === 'en' ? 'Copy link' : 'Copiar link'"
+      @click="copyLink"
+    >
+      <span class="material-icons text-sm">{{ copied ? 'check' : 'content_copy' }}</span>
+      {{ copied ? copyLabel.copied : copyLabel.copy }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref } from 'vue'
+import type { Lang } from '~/composables/useBlog'
+
+const props = defineProps<{
+  url: string
+  title: string
+  lang?: Lang
+}>()
+
+const lang = computed<Lang>(() => props.lang ?? 'pt-BR')
+
+const encodedUrl = computed(() => encodeURIComponent(props.url))
+const encodedTitle = computed(() => encodeURIComponent(props.title))
+
+const copyLabel = computed(() =>
+  lang.value === 'en'
+    ? { copy: 'Copy link', copied: 'Copied!' }
+    : { copy: 'Copiar link', copied: 'Copiado!' },
+)
+
+const copied = ref(false)
+let resetTimer: ReturnType<typeof setTimeout> | null = null
+
+async function copyLink() {
+  try {
+    await navigator.clipboard.writeText(props.url)
+    copied.value = true
+    if (resetTimer) clearTimeout(resetTimer)
+    resetTimer = setTimeout(() => {
+      copied.value = false
+    }, 2000)
+  } catch {
+    // Best-effort. If clipboard write fails (Safari permission edge
+    // cases) the user can still copy from the address bar.
+  }
+}
+
+onBeforeUnmount(() => {
+  if (resetTimer) clearTimeout(resetTimer)
+})
+</script>

--- a/components/blog/BlogTagPill.vue
+++ b/components/blog/BlogTagPill.vue
@@ -1,0 +1,22 @@
+<template>
+  <component
+    :is="href ? 'NuxtLink' : 'span'"
+    :to="href"
+    :class="[
+      'inline-flex items-center px-2.5 py-1 rounded-md text-xs mono transition-colors',
+      active
+        ? 'bg-[var(--accent-muted)] text-[var(--accent)] border border-[var(--accent)]/40'
+        : 'bg-[var(--bg-secondary)] text-[var(--text-muted)] border border-[var(--border)] hover:border-[var(--accent)]/40 hover:text-[var(--accent)]',
+    ]"
+  >
+    #{{ label }}
+  </component>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  label: string
+  href?: string
+  active?: boolean
+}>()
+</script>

--- a/components/blog/LatestPosts.vue
+++ b/components/blog/LatestPosts.vue
@@ -1,0 +1,82 @@
+<template>
+  <section id="blog" class="py-24">
+    <div class="glow-line mb-24"></div>
+    <div class="section-container">
+      <div class="flex items-end justify-between gap-6 mb-12 flex-wrap">
+        <div>
+          <div class="flex items-center gap-3 mb-4">
+            <span class="mono text-[var(--accent)] text-sm">04.</span>
+            <h2 class="text-3xl md:text-4xl font-bold">Últimas Postagens</h2>
+          </div>
+          <p class="text-[var(--text-muted)] max-w-2xl">
+            Notas técnicas, postmortems e experimentos.
+          </p>
+        </div>
+        <NuxtLink
+          to="/blog"
+          class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border)] text-sm mono text-[var(--text-primary)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
+        >
+          Ver todos
+          <span class="material-icons text-base">arrow_forward</span>
+        </NuxtLink>
+      </div>
+
+      <!-- Loading skeleton -->
+      <div
+        v-if="pending"
+        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+      >
+        <div
+          v-for="n in limit"
+          :key="n"
+          class="aspect-[4/5] rounded-2xl border border-[var(--border)] bg-[var(--surface)] animate-pulse"
+        ></div>
+      </div>
+
+      <!-- Error fallback: hide the section silently rather than break
+           the home page if the blog API is down. -->
+      <div v-else-if="error || !posts || posts.length === 0" class="hidden"></div>
+
+      <!-- Cards -->
+      <div
+        v-else
+        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+      >
+        <BlogCard
+          v-for="post in posts"
+          :key="post.id"
+          :post="post"
+          :lang="lang"
+        />
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { useAsyncData } from 'nuxt/app'
+import { useBlog, type Lang, type BlogPost } from '~/composables/useBlog'
+
+const props = withDefaults(
+  defineProps<{
+    lang?: Lang
+    limit?: number
+  }>(),
+  {
+    lang: 'pt-BR',
+    limit: 3,
+  },
+)
+
+const { data: posts, pending, error } = await useAsyncData<BlogPost[]>(
+  `blog-latest-${props.lang}-${props.limit}`,
+  () => useBlog().getLatest(props.lang, props.limit),
+  {
+    // Re-fetch when the home page revalidates (SWR handles this at the
+    // route level; keep the composable cache-friendly).
+    server: true,
+    lazy: false,
+    default: () => [],
+  },
+)
+</script>

--- a/components/blog/MarkdownContent.vue
+++ b/components/blog/MarkdownContent.vue
@@ -1,0 +1,177 @@
+<template>
+  <!-- HTML comes from the SSR-rendered Markdown pipeline (markdown-it +
+       shiki). Author-supplied HTML is disabled in the renderer so this
+       v-html is safe given the trusted authoring path (admin only). -->
+  <article
+    class="prose-blog max-w-none"
+    v-html="html"
+  ></article>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  html: string
+}>()
+</script>
+
+<style>
+/* Local prose styles — keeps the article matching the portfolio's
+   industrial/terminal feel without pulling in @tailwindcss/typography. */
+.prose-blog {
+  color: var(--text-secondary);
+  font-family: 'General Sans', 'Inter', system-ui, sans-serif;
+  line-height: 1.7;
+  font-size: 1.0625rem;
+}
+
+.prose-blog > * + * {
+  margin-top: 1.25rem;
+}
+
+.prose-blog h1,
+.prose-blog h2,
+.prose-blog h3,
+.prose-blog h4 {
+  color: var(--text-primary);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.prose-blog h2 {
+  font-size: 1.875rem;
+  scroll-margin-top: 96px;
+}
+
+.prose-blog h3 {
+  font-size: 1.5rem;
+  scroll-margin-top: 96px;
+}
+
+.prose-blog h4 {
+  font-size: 1.25rem;
+}
+
+.prose-blog a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid color-mix(in oklab, var(--accent) 40%, transparent);
+  transition: border-color 150ms;
+}
+
+.prose-blog a:hover {
+  border-bottom-color: var(--accent);
+}
+
+.prose-blog ul,
+.prose-blog ol {
+  padding-left: 1.5rem;
+}
+
+.prose-blog ul {
+  list-style: none;
+}
+
+.prose-blog ul > li {
+  position: relative;
+  padding-left: 1.25rem;
+}
+
+.prose-blog ul > li::before {
+  content: '▹';
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+}
+
+.prose-blog ol {
+  list-style: decimal;
+}
+
+.prose-blog ol > li::marker {
+  color: var(--accent);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.875rem;
+}
+
+.prose-blog blockquote {
+  border-left: 3px solid var(--accent);
+  padding: 0.75rem 1.25rem;
+  background: var(--bg-secondary);
+  border-radius: 0 0.5rem 0.5rem 0;
+  font-style: italic;
+  color: var(--text-primary);
+}
+
+.prose-blog code {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.875em;
+  padding: 0.125rem 0.375rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  color: var(--accent);
+}
+
+.prose-blog pre {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  overflow-x: auto;
+  font-size: 0.875rem;
+  line-height: 1.6;
+}
+
+.prose-blog pre code {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+}
+
+/* Shiki produces two themes; toggle by the same dark/light class the
+   rest of the site uses (see assets/css/colors.css). */
+html.dark .prose-blog pre,
+html.dark .prose-blog pre code {
+  background-color: var(--bg-secondary);
+  color: var(--shiki-dark, var(--text-primary)) !important;
+}
+
+html.light .prose-blog pre,
+html.light .prose-blog pre code {
+  color: var(--shiki-light, var(--text-primary)) !important;
+}
+
+.prose-blog img {
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  margin: 1.5rem auto;
+}
+
+.prose-blog hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 2.5rem 0;
+}
+
+.prose-blog table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9375rem;
+}
+
+.prose-blog th,
+.prose-blog td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+.prose-blog th {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+</style>

--- a/composables/useBlog.ts
+++ b/composables/useBlog.ts
@@ -1,0 +1,142 @@
+/**
+ * Public-blog composable. All requests go through the local
+ * /api/blog/* proxy (server-side handler injects X-Tenant-ID).
+ * Types mirror rb_management_api features/posts/domain/entities.
+ */
+
+export type Lang = 'pt-BR' | 'en'
+
+export type PostStatus = 'draft' | 'scheduled' | 'published' | 'archived'
+
+export interface PostTranslation {
+  id?: string
+  post_id?: string
+  tenant_id?: string
+  lang: Lang
+  slug: string
+  title: string
+  excerpt?: string
+  content_md: string
+  seo_title?: string
+  seo_description?: string
+  created_at?: string
+  updated_at?: string
+}
+
+export interface TagTranslation {
+  tag_id?: string
+  lang: Lang
+  name: string
+}
+
+export interface BlogTag {
+  id: string
+  tenant_id: string
+  slug: string
+  created_at: string
+  translations?: TagTranslation[]
+  post_count?: number
+}
+
+export interface BlogPost {
+  id: string
+  tenant_id: string
+  author_identity_id: string
+  status: PostStatus
+  published_at?: string | null
+  cover_image_url?: string
+  og_image_url?: string
+  reading_time_minutes: number
+  view_count: number
+  featured: boolean
+  created_at: string
+  updated_at: string
+  translations?: PostTranslation[]
+  tags?: BlogTag[]
+}
+
+export interface BlogListResponse {
+  items: BlogPost[]
+  page: number
+  page_size: number
+  total: number
+}
+
+interface BlogListFilter {
+  lang?: Lang
+  tag?: string
+  q?: string
+  page?: number
+  per_page?: number
+}
+
+export function useBlog() {
+  return {
+    /** Most-recent N published posts — for the home widget. */
+    async getLatest(lang: Lang = 'pt-BR', limit = 3): Promise<BlogPost[]> {
+      return $fetch<BlogPost[]>('/api/blog/posts/latest', {
+        query: { lang, limit },
+      })
+    },
+
+    /** Paginated list with filters — for the /blog page. */
+    async getList(filter: BlogListFilter = {}): Promise<BlogListResponse> {
+      return $fetch<BlogListResponse>('/api/blog/posts', {
+        query: {
+          lang: filter.lang ?? 'pt-BR',
+          tag: filter.tag,
+          q: filter.q,
+          page: filter.page,
+          per_page: filter.per_page,
+        },
+      })
+    },
+
+    /** Single post by slug + lang — for /blog/[slug]. */
+    async getBySlug(slug: string, lang: Lang = 'pt-BR'): Promise<BlogPost> {
+      return $fetch<BlogPost>(`/api/blog/posts/by-slug/${slug}`, {
+        query: { lang },
+      })
+    },
+
+    /** Tag taxonomy with post counts — for the filter chips. */
+    async getTags(): Promise<BlogTag[]> {
+      return $fetch<BlogTag[]>('/api/blog/tags')
+    },
+
+    /**
+     * Fire-and-forget view tracker. Upstream dedup keyed on (post, IP)
+     * for 24h, so repeated calls from the same client are cheap. Don't
+     * await the response — failure here should never break the article
+     * page render.
+     */
+    registerView(slug: string, lang: Lang = 'pt-BR'): void {
+      $fetch(`/api/blog/posts/by-slug/${slug}/view`, {
+        method: 'POST',
+        query: { lang },
+      }).catch(() => {
+        /* silent */
+      })
+    },
+  }
+}
+
+/**
+ * Pick the translation for a given language, falling back to the first
+ * available one (the API always sends at least one).
+ */
+export function pickTranslation(
+  post: BlogPost,
+  lang: Lang,
+): PostTranslation | undefined {
+  if (!post.translations || post.translations.length === 0) return undefined
+  return (
+    post.translations.find((t) => t.lang === lang) ?? post.translations[0]
+  )
+}
+
+/** Tag name in the requested language, falling back to the slug. */
+export function pickTagName(tag: BlogTag, lang: Lang): string {
+  const t = tag.translations?.find((tr) => tr.lang === lang)
+  return t?.name ?? tag.slug
+}

--- a/composables/useBlog.ts
+++ b/composables/useBlog.ts
@@ -38,10 +38,16 @@ export interface BlogTag {
   post_count?: number
 }
 
+export interface BlogAuthor {
+  sub: string
+  name: string
+  email?: string
+}
+
 export interface BlogPost {
   id: string
   tenant_id: string
-  author_identity_id: string
+  author: BlogAuthor
   status: PostStatus
   published_at?: string | null
   cover_image_url?: string

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,10 @@
 import tailwindcss from '@tailwindcss/vite'
 
 export default defineNuxtConfig({
-  target: 'static',
+  // Note: `target: 'static'` is a Nuxt 2 leftover and is ignored by
+  // Nuxt 4 — the actual deploy target is the Nitro preset, which the
+  // Dockerfile already runs as `node .output/server/index.mjs`.
+  // Removed so the actual mode (Node server) is unambiguous.
 
   typescript: {
     typeCheck: true,
@@ -13,6 +16,12 @@ export default defineNuxtConfig({
   },
 
   runtimeConfig: {
+    // Server-only — never sent to the client. Both env vars come from
+    // the Helm chart (values-{stg,prod}.yaml -> Vault).
+    blogApiUrl:
+      process.env.BLOG_API_URL ||
+      'https://api.management.rodolfodebonis.com.br',
+    blogTenantId: process.env.BLOG_TENANT_ID || '',
     public: {
       cdnApiKey: process.env.CDN_API_KEY,
     },
@@ -100,8 +109,24 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-01-30',
   devtools: { enabled: true },
 
+  // SWR (stale-while-revalidate) for the blog routes: the HTML is
+  // pre-rendered at build/first-hit, served instantly on subsequent
+  // requests, and revalidated in the background after the TTL. The
+  // home page rebuilds every 10 min so a freshly-published post shows
+  // up in the "Últimas postagens" section without a manual rebuild.
   routeRules: {
     '/**': { ssr: true },
     '/_nuxt/**': { static: true },
+
+    '/': { swr: 600 },                        // 10 min — refresh latest posts
+    '/blog': { swr: 300 },                    // 5 min — list page
+    '/blog/**': { swr: 600 },                 // 10 min — article detail
+    '/en/blog': { swr: 300 },
+    '/en/blog/**': { swr: 600 },
+
+    // The proxy under /api/blog should never be cached (it forwards
+    // tenant-scoped headers and we want every revalidation to hit a
+    // fresh upstream response).
+    '/api/blog/**': { cache: false },
   },
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,10 @@
         "@vueuse/core": "^13.3.0",
         "@vueuse/nuxt": "^13.3.0",
         "h3": "^1.15.3",
+        "markdown-it": "^14.1.1",
         "material-design-icons-iconfont": "^6.7.0",
         "nuxt": "^4.0.3",
+        "shiki": "^4.0.2",
         "vue": "^3.5.13"
       },
       "devDependencies": {
@@ -26,6 +28,7 @@
         "@nuxtjs/eslint-config-typescript": "^12.0.0",
         "@tailwindcss/cli": "^4.1.8",
         "@tailwindcss/postcss": "^4.1.8",
+        "@types/markdown-it": "^14.1.2",
         "@types/node": "^24.2.1",
         "autoprefixer": "^10.4.21",
         "eslint": "^8.24.0",
@@ -1308,92 +1311,6 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/config-array": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.2.tgz",
-      "integrity": "sha512-YF+fE6LV4v5MGWRGj7G404/OZzGNepVF8fxk7jqmqo3lrza7a0uUcDnROGRBG1WFC1omYUS/Wp1f42i0M+3Q3A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@eslint/object-schema": "^3.0.2",
-        "debug": "^4.3.1",
-        "minimatch": "^10.2.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@eslint/config-helpers": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
-      "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@eslint/core": "^1.1.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
@@ -1486,58 +1403,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/object-schema": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.2.tgz",
-      "integrity": "sha512-HOy56KJt48Bx8KmJ+XGQNSUMT/6dZee/M54XyUyuvTvPXJmsERRvBchsUVx1UMe1WwIH49XLAczNC7V2INsuUw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/plugin-kit": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
-      "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@eslint/core": "^1.1.0",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1599,21 +1464,6 @@
       "deprecated": "Use @eslint/object-schema instead",
       "devOptional": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
-      }
     },
     "node_modules/@ioredis/commands": {
       "version": "1.5.0",
@@ -2567,49 +2417,6 @@
         "node": ">=18.12.0"
       }
     },
-    "node_modules/@nuxt/vite-builder/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@nuxt/vite-builder/node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -2637,244 +2444,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@nuxt/vite-builder/node_modules/eslint": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
-      "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.2",
-        "@eslint/config-helpers": "^0.5.2",
-        "@eslint/core": "^1.1.0",
-        "@eslint/plugin-kit": "^0.6.0",
-        "@humanfs/node": "^0.16.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
-        "@types/estree": "^1.0.6",
-        "ajv": "^6.14.0",
-        "cross-spawn": "^7.0.6",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.1",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.1.1",
-        "esquery": "^1.7.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "jiti": "*"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/eslint-scope": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.1.tgz",
-      "integrity": "sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/eslint/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/eslint/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/espree": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.1.tgz",
-      "integrity": "sha512-AVHPqQoZYc+RUM4/3Ly5udlZY/U4LS8pIG05jEjWM2lQMU/oaZ7qshzAl2YP1tfNmXfftH3ohurfwNAug+MnsQ==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "flat-cache": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/flat-cache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/meow": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@nuxt/vite-builder/node_modules/npm-run-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -2889,51 +2458,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@nuxt/vite-builder/node_modules/path-key": {
@@ -3052,20 +2576,6 @@
         "vue-tsc": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@nuxtjs/color-mode": {
@@ -5003,6 +4513,106 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/@shikijs%2fcore/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/@shikijs%2fengine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/@shikijs%2fengine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/@shikijs%2flangs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/@shikijs%2fprimitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/@shikijs%2fthemes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/@shikijs%2ftypes/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/@shikijs%2fvscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
@@ -5450,14 +5060,6 @@
         "@types/estree": "*"
       }
     },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5525,6 +5127,15 @@
         "@types/webpack": "^4"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://npm.rodolfodebonis.com.br/@types%2fhast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-7.0.2.tgz",
@@ -5562,6 +5173,40 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/@types%2flinkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/@types%2fmarkdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://npm.rodolfodebonis.com.br/@types%2fmdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/@types%2fmdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.10.13",
@@ -5724,6 +5369,12 @@
       "dependencies": {
         "source-map": "^0.6.1"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://npm.rodolfodebonis.com.br/@types%2funist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.21",
@@ -6006,7 +5657,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/@unhead/vue": {
@@ -7390,7 +7040,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "devOptional": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -8054,6 +7703,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://npm.rodolfodebonis.com.br/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -8065,6 +7724,26 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -8214,15 +7893,14 @@
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "license": "MIT"
     },
-    "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://npm.rodolfodebonis.com.br/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://npm.rodolfodebonis.com.br/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commondir": {
@@ -8904,6 +8582,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://npm.rodolfodebonis.com.br/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
@@ -8924,6 +8611,19 @@
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.3.tgz",
       "integrity": "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/diff": {
       "version": "8.0.3",
@@ -11351,6 +11051,42 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://npm.rodolfodebonis.com.br/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -11373,6 +11109,16 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -12806,6 +12552,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/listhen": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.9.0.tgz",
@@ -13064,6 +12819,35 @@
         "source-map-js": "^1.2.1"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://npm.rodolfodebonis.com.br/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/material-design-icons-iconfont": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/material-design-icons-iconfont/-/material-design-icons-iconfont-6.7.0.tgz",
@@ -13080,11 +12864,38 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://npm.rodolfodebonis.com.br/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/memfs": {
       "version": "3.5.3",
@@ -13180,6 +12991,95 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://npm.rodolfodebonis.com.br/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://npm.rodolfodebonis.com.br/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://npm.rodolfodebonis.com.br/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://npm.rodolfodebonis.com.br/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -14170,6 +14070,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://npm.rodolfodebonis.com.br/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/open": {
@@ -15215,6 +15132,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -15227,6 +15154,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://npm.rodolfodebonis.com.br/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15515,6 +15451,30 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
     },
     "node_modules/regexp-tree": {
       "version": "0.1.27",
@@ -16105,6 +16065,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -16273,6 +16252,16 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/spdx-correct": {
@@ -16490,6 +16479,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://npm.rodolfodebonis.com.br/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -16956,6 +16959,16 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://npm.rodolfodebonis.com.br/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -17201,6 +17214,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/ufo": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
@@ -17436,6 +17455,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://npm.rodolfodebonis.com.br/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://npm.rodolfodebonis.com.br/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://npm.rodolfodebonis.com.br/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {
@@ -17846,6 +17933,34 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://npm.rodolfodebonis.com.br/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://npm.rodolfodebonis.com.br/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -18736,6 +18851,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://npm.rodolfodebonis.com.br/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
     "@vueuse/core": "^13.3.0",
     "@vueuse/nuxt": "^13.3.0",
     "h3": "^1.15.3",
+    "markdown-it": "^14.1.1",
     "material-design-icons-iconfont": "^6.7.0",
     "nuxt": "^4.0.3",
+    "shiki": "^4.0.2",
     "vue": "^3.5.13"
   },
   "devDependencies": {
@@ -38,6 +40,7 @@
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
     "@tailwindcss/cli": "^4.1.8",
     "@tailwindcss/postcss": "^4.1.8",
+    "@types/markdown-it": "^14.1.2",
     "@types/node": "^24.2.1",
     "autoprefixer": "^10.4.21",
     "eslint": "^8.24.0",

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <MainHeader />
+    <main class="min-h-screen">
+      <BlogArticle :slug="slug" lang="pt-BR" />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+const slug = computed(() => String(route.params.slug ?? ''))
+</script>

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -1,0 +1,44 @@
+<template>
+  <div>
+    <MainHeader />
+    <main class="min-h-screen">
+      <BlogList lang="pt-BR" />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useHead, useSeoMeta } from 'nuxt/app'
+
+useSeoMeta({
+  title: 'Blog — Rodolfo De Bonis',
+  description:
+    'Notas técnicas, postmortems e experimentos sobre Go, observabilidade, multi-tenancy e infraestrutura.',
+  ogTitle: 'Blog — Rodolfo De Bonis',
+  ogDescription:
+    'Artigos técnicos sobre Go, sistemas distribuídos e DevOps.',
+  ogUrl: 'https://rodolfodebonis.com.br/blog',
+  ogType: 'website',
+})
+
+useHead({
+  link: [
+    { rel: 'canonical', href: 'https://rodolfodebonis.com.br/blog' },
+    {
+      rel: 'alternate',
+      hreflang: 'en',
+      href: 'https://rodolfodebonis.com.br/en/blog',
+    },
+    {
+      rel: 'alternate',
+      hreflang: 'pt-BR',
+      href: 'https://rodolfodebonis.com.br/blog',
+    },
+    {
+      rel: 'alternate',
+      hreflang: 'x-default',
+      href: 'https://rodolfodebonis.com.br/blog',
+    },
+  ],
+})
+</script>

--- a/pages/en/blog/[slug].vue
+++ b/pages/en/blog/[slug].vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <MainHeader />
+    <main class="min-h-screen">
+      <BlogArticle :slug="slug" lang="en" />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+const slug = computed(() => String(route.params.slug ?? ''))
+</script>

--- a/pages/en/blog/index.vue
+++ b/pages/en/blog/index.vue
@@ -1,0 +1,45 @@
+<template>
+  <div>
+    <MainHeader />
+    <main class="min-h-screen">
+      <BlogList lang="en" />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useHead, useSeoMeta } from 'nuxt/app'
+
+useSeoMeta({
+  title: 'Blog — Rodolfo De Bonis',
+  description:
+    'Technical notes, postmortems and experiments on Go, observability, multi-tenancy and infrastructure.',
+  ogTitle: 'Blog — Rodolfo De Bonis',
+  ogDescription:
+    'Technical articles on Go, distributed systems and DevOps.',
+  ogUrl: 'https://rodolfodebonis.com.br/en/blog',
+  ogType: 'website',
+})
+
+useHead({
+  htmlAttrs: { lang: 'en' },
+  link: [
+    { rel: 'canonical', href: 'https://rodolfodebonis.com.br/en/blog' },
+    {
+      rel: 'alternate',
+      hreflang: 'pt-BR',
+      href: 'https://rodolfodebonis.com.br/blog',
+    },
+    {
+      rel: 'alternate',
+      hreflang: 'en',
+      href: 'https://rodolfodebonis.com.br/en/blog',
+    },
+    {
+      rel: 'alternate',
+      hreflang: 'x-default',
+      href: 'https://rodolfodebonis.com.br/blog',
+    },
+  ],
+})
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,6 +6,7 @@
       <About />
       <Stacks />
       <Projects />
+      <BlogLatestPosts lang="pt-BR" :limit="3" />
       <Experience />
       <Contact />
     </main>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://rodolfodebonis.com.br/sitemap.xml

--- a/server/api/blog/[...path].ts
+++ b/server/api/blog/[...path].ts
@@ -1,0 +1,124 @@
+import {
+  defineEventHandler,
+  getRouterParam,
+  getQuery,
+  getRequestHeaders,
+  createError,
+  setResponseHeader,
+  setResponseStatus,
+  readBody,
+  getMethod,
+} from 'h3'
+import { $fetch, FetchError } from 'ofetch'
+
+/**
+ * Server-side proxy for the bilingual blog public API.
+ *
+ * The browser hits `/api/blog/posts?lang=pt-BR` and we forward it to
+ * `<BLOG_API_URL>/v1/public/posts?lang=pt-BR` while injecting the
+ * tenant header from BLOG_TENANT_ID (Helm-injected from Vault). Two
+ * benefits:
+ *   1. The API URL + tenant id stay server-only — no leakage to the
+ *      browser.
+ *   2. The Helm-managed tenant id can change without re-publishing
+ *      a JS bundle.
+ *
+ * Routes proxied:
+ *   GET  /api/blog/posts                        → /v1/public/posts
+ *   GET  /api/blog/posts/latest                 → /v1/public/posts/latest
+ *   GET  /api/blog/posts/by-slug/:slug          → /v1/public/posts/by-slug/:slug
+ *   POST /api/blog/posts/by-slug/:slug/view     → /v1/public/posts/by-slug/:slug/view
+ *   GET  /api/blog/tags                         → /v1/public/tags
+ *
+ * Cache passthrough: relays the upstream Cache-Control + ETag so the
+ * browser/CDN respects the same TTL the Go API set.
+ */
+export default defineEventHandler(async (event) => {
+  const path = getRouterParam(event, 'path')
+  if (!path) {
+    throw createError({
+      statusCode: 400,
+      message: 'Path required',
+    })
+  }
+
+  // Read directly from env so we don't depend on the Nuxt runtime
+  // config typing in the Nitro context. Defaults match nuxt.config.
+  const baseUrl = (
+    process.env.BLOG_API_URL || 'https://api.management.rodolfodebonis.com.br'
+  ).replace(/\/$/, '')
+  const tenantId = process.env.BLOG_TENANT_ID || ''
+
+  if (!tenantId) {
+    // Loud-fail: an empty tenant id means the API would 400 every
+    // request anyway. Surface the misconfig instead of returning
+    // confusing upstream errors.
+    throw createError({
+      statusCode: 503,
+      message:
+        'Blog proxy not configured: BLOG_TENANT_ID is unset. Check Helm values + Vault.',
+    })
+  }
+
+  const upstreamPath = `/v1/public/${path}`
+  const query = getQuery(event)
+  const method = getMethod(event)
+  const incomingHeaders = getRequestHeaders(event)
+
+  // Forward only the headers the upstream cares about. Strip
+  // host/cookie/auth so the proxy doesn't accidentally leak the
+  // browser's session into the upstream request.
+  const forward: Record<string, string> = {
+    'X-Tenant-ID': tenantId,
+    'Accept-Language': incomingHeaders['accept-language'] ?? 'pt-BR',
+  }
+  if (incomingHeaders['if-none-match']) {
+    forward['If-None-Match'] = incomingHeaders['if-none-match']
+  }
+  // Use the real client IP for view dedup keying upstream.
+  if (incomingHeaders['x-forwarded-for']) {
+    forward['X-Forwarded-For'] = incomingHeaders['x-forwarded-for']
+  }
+
+  let body: Record<string, unknown> | undefined
+  if (method !== 'GET' && method !== 'HEAD') {
+    body = (await readBody(event).catch(() => undefined)) as
+      | Record<string, unknown>
+      | undefined
+  }
+
+  try {
+    const response = await $fetch.raw(`${baseUrl}${upstreamPath}`, {
+      method: method as 'GET' | 'POST',
+      query: query as Record<string, string>,
+      headers: forward,
+      body,
+      // Don't throw on non-2xx so we can pass through the upstream
+      // status to the browser (especially 304 Not Modified).
+      ignoreResponseError: true,
+    })
+
+    // Pass cache headers through so the CDN/browser honour the upstream
+    // TTL set by the Go API (max-age + s-maxage + ETag).
+    for (const header of ['cache-control', 'etag', 'last-modified']) {
+      const value = response.headers.get(header)
+      if (value) setResponseHeader(event, header, value)
+    }
+
+    setResponseStatus(event, response.status)
+    return response._data
+  } catch (error) {
+    // Genuine network/transport error — log and 502.
+    if (error instanceof FetchError) {
+      console.error('[blog proxy] upstream error', {
+        path: upstreamPath,
+        status: error.statusCode,
+        message: error.message,
+      })
+    }
+    throw createError({
+      statusCode: 502,
+      message: 'Blog API unreachable',
+    })
+  }
+})

--- a/server/api/blog/render/[...slug].ts
+++ b/server/api/blog/render/[...slug].ts
@@ -1,0 +1,48 @@
+import {
+  defineEventHandler,
+  getRouterParam,
+  getQuery,
+  setResponseHeader,
+  createError,
+} from 'h3'
+import { renderMarkdown } from '~/server/utils/renderMarkdown'
+
+/**
+ * Server-side endpoint that fetches a post via the local blog proxy
+ * AND renders its Markdown to HTML in the same request. The page
+ * component awaits the response in setup, so the Vue tree gets the
+ * already-rendered HTML and Shiki never reaches the browser.
+ *
+ * Cache: 5 min public, 1h shared (matches the upstream detail TTL).
+ */
+export default defineEventHandler(async (event) => {
+  const slug = getRouterParam(event, 'slug')
+  if (!slug) {
+    throw createError({ statusCode: 400, message: 'slug required' })
+  }
+  const lang = (getQuery(event).lang as string) || 'pt-BR'
+
+  const post = await $fetch<{
+    id: string
+    translations?: Array<{ lang: string; content_md: string; title: string }>
+    [k: string]: unknown
+  }>(`/api/blog/posts/by-slug/${slug}`, {
+    query: { lang },
+  })
+
+  const translation = post.translations?.find((t) => t.lang === lang)
+  const content = translation?.content_md ?? ''
+  const rendered = await renderMarkdown(content)
+
+  setResponseHeader(
+    event,
+    'Cache-Control',
+    'public, max-age=300, s-maxage=3600',
+  )
+
+  return {
+    post,
+    html: rendered.html,
+    reading_time_minutes: rendered.readingTimeMinutes,
+  }
+})

--- a/server/routes/sitemap.xml.ts
+++ b/server/routes/sitemap.xml.ts
@@ -1,0 +1,153 @@
+import { defineEventHandler, setResponseHeader } from 'h3'
+import { $fetch } from 'ofetch'
+
+interface PostStub {
+  id: string
+  published_at?: string | null
+  updated_at?: string
+  translations?: Array<{ lang: string; slug: string; updated_at?: string }>
+}
+
+interface ListResponse {
+  items: PostStub[]
+  total: number
+}
+
+const BASE = 'https://rodolfodebonis.com.br'
+
+/**
+ * Dynamic sitemap. Lists every public post in both languages with
+ * cross-hreflang annotations so search engines understand the
+ * PT↔EN pairing without guessing from the URL pattern.
+ *
+ * Static routes (home, /blog, /en/blog) come first; per-post entries
+ * follow. Cached 1h shared so rebuild storms don't hammer the API.
+ */
+export default defineEventHandler(async (event) => {
+  const baseUrl = (
+    process.env.BLOG_API_URL || 'https://api.management.rodolfodebonis.com.br'
+  ).replace(/\/$/, '')
+  const tenantId = process.env.BLOG_TENANT_ID || ''
+
+  let postsPT: PostStub[] = []
+  let postsEN: PostStub[] = []
+
+  if (tenantId) {
+    try {
+      const [pt, en] = await Promise.all([
+        $fetch<ListResponse>(`${baseUrl}/v1/public/posts`, {
+          query: { lang: 'pt-BR', per_page: 500 },
+          headers: { 'X-Tenant-ID': tenantId },
+        }),
+        $fetch<ListResponse>(`${baseUrl}/v1/public/posts`, {
+          query: { lang: 'en', per_page: 500 },
+          headers: { 'X-Tenant-ID': tenantId },
+        }),
+      ])
+      postsPT = pt.items ?? []
+      postsEN = en.items ?? []
+    } catch (err) {
+      // Don't fail the sitemap on API hiccup — emit just the static
+      // routes. Better a partial sitemap than a 5xx.
+      console.error('[sitemap] blog fetch failed', err)
+    }
+  }
+
+  // Build per-post URL entries with bilingual alternates. Group by
+  // post.id so the same physical post under two slugs links each other.
+  const byID = new Map<
+    string,
+    { pt?: { slug: string; updated: string }; en?: { slug: string; updated: string } }
+  >()
+
+  function recordTranslation(
+    list: PostStub[],
+    lang: 'pt' | 'en',
+  ) {
+    for (const p of list) {
+      // Translation list comes scoped to the requested lang (lang query
+      // on the public list). Fall back to the post's first translation
+      // if the API returns the post without translations attached.
+      const t =
+        p.translations?.find((tr) => tr.lang === (lang === 'pt' ? 'pt-BR' : 'en')) ??
+        p.translations?.[0]
+      if (!t) continue
+      const entry = byID.get(p.id) ?? {}
+      entry[lang] = { slug: t.slug, updated: t.updated_at ?? p.updated_at ?? '' }
+      byID.set(p.id, entry)
+    }
+  }
+  recordTranslation(postsPT, 'pt')
+  recordTranslation(postsEN, 'en')
+
+  const staticEntries: Array<{ loc: string; lastmod?: string; alternates?: { hreflang: string; href: string }[] }> = [
+    { loc: `${BASE}/`, lastmod: new Date().toISOString() },
+    {
+      loc: `${BASE}/blog`,
+      lastmod: new Date().toISOString(),
+      alternates: [
+        { hreflang: 'pt-BR', href: `${BASE}/blog` },
+        { hreflang: 'en', href: `${BASE}/en/blog` },
+        { hreflang: 'x-default', href: `${BASE}/blog` },
+      ],
+    },
+    {
+      loc: `${BASE}/en/blog`,
+      lastmod: new Date().toISOString(),
+      alternates: [
+        { hreflang: 'pt-BR', href: `${BASE}/blog` },
+        { hreflang: 'en', href: `${BASE}/en/blog` },
+        { hreflang: 'x-default', href: `${BASE}/blog` },
+      ],
+    },
+  ]
+
+  const postEntries: Array<{ loc: string; lastmod: string; alternates: { hreflang: string; href: string }[] }> = []
+  for (const entry of byID.values()) {
+    const ptHref = entry.pt ? `${BASE}/blog/${entry.pt.slug}` : null
+    const enHref = entry.en ? `${BASE}/en/blog/${entry.en.slug}` : null
+    const alternates: { hreflang: string; href: string }[] = []
+    if (ptHref) alternates.push({ hreflang: 'pt-BR', href: ptHref })
+    if (enHref) alternates.push({ hreflang: 'en', href: enHref })
+    alternates.push({ hreflang: 'x-default', href: ptHref ?? enHref ?? BASE })
+
+    if (ptHref) {
+      postEntries.push({
+        loc: ptHref,
+        lastmod: entry.pt?.updated || new Date().toISOString(),
+        alternates,
+      })
+    }
+    if (enHref) {
+      postEntries.push({
+        loc: enHref,
+        lastmod: entry.en?.updated || new Date().toISOString(),
+        alternates,
+      })
+    }
+  }
+
+  const all = [...staticEntries, ...postEntries]
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+${all
+  .map((entry) => {
+    const altLines = (entry.alternates ?? [])
+      .map(
+        (a) =>
+          `    <xhtml:link rel="alternate" hreflang="${a.hreflang}" href="${a.href}"/>`,
+      )
+      .join('\n')
+    return `  <url>
+    <loc>${entry.loc}</loc>${entry.lastmod ? `\n    <lastmod>${new Date(entry.lastmod).toISOString()}</lastmod>` : ''}${altLines ? '\n' + altLines : ''}
+  </url>`
+  })
+  .join('\n')}
+</urlset>`
+
+  setResponseHeader(event, 'Content-Type', 'application/xml; charset=utf-8')
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=900, s-maxage=3600')
+  return xml
+})

--- a/server/utils/renderMarkdown.ts
+++ b/server/utils/renderMarkdown.ts
@@ -1,0 +1,116 @@
+/**
+ * Server-side Markdown→HTML renderer for blog articles.
+ *
+ * Pipeline: markdown-it (CommonMark + GFM tables/lists) → shiki for
+ * fenced code blocks (dual theme dark+light, switched by the same
+ * .dark/.light class the rest of the site uses).
+ *
+ * Why server-side: Nuxt SSR renders the article once, then SWR caches
+ * the HTML. Shiki ships ~7MB of grammar files but never reaches the
+ * browser — only the highlighted <pre><code> output does.
+ */
+
+import MarkdownIt from 'markdown-it'
+import { createHighlighter, type Highlighter } from 'shiki'
+
+// Languages we actually use in posts. Adding more is cheap; pick the
+// ones present in real articles to keep highlighter startup fast.
+const LANGS = [
+  'go',
+  'typescript',
+  'javascript',
+  'tsx',
+  'jsx',
+  'vue',
+  'bash',
+  'shell',
+  'json',
+  'yaml',
+  'sql',
+  'dockerfile',
+  'python',
+  'rust',
+  'css',
+  'html',
+  'diff',
+] as const
+
+const THEMES = {
+  dark: 'github-dark',
+  light: 'github-light',
+} as const
+
+let highlighterPromise: Promise<Highlighter> | null = null
+
+async function getHighlighter(): Promise<Highlighter> {
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter({
+      themes: [THEMES.dark, THEMES.light],
+      langs: [...LANGS],
+    })
+  }
+  return highlighterPromise
+}
+
+let mdInstance: MarkdownIt | null = null
+
+async function getRenderer(): Promise<MarkdownIt> {
+  if (mdInstance) return mdInstance
+  const highlighter = await getHighlighter()
+
+  const md = new MarkdownIt({
+    html: false, // never trust author-supplied HTML in posts
+    linkify: true,
+    typographer: true,
+    breaks: false,
+    highlight: (code, lang) => {
+      const safeLang = (LANGS as readonly string[]).includes(lang)
+        ? lang
+        : 'text'
+      try {
+        return highlighter.codeToHtml(code, {
+          lang: safeLang,
+          themes: THEMES,
+          // Defaults to <pre><code>… ; we wrap to give the same look as
+          // ProjectCard code blocks in the existing portfolio.
+          defaultColor: false,
+        })
+      } catch {
+        // Fallback: plain escaped <pre><code>. markdown-it does the
+        // escape itself if we return empty string.
+        return ''
+      }
+    },
+  })
+
+  // Open external links in a new tab and add rel for SEO/security.
+  const defaultLinkRender =
+    md.renderer.rules.link_open ||
+    ((tokens, idx, options, _env, self) =>
+      self.renderToken(tokens, idx, options))
+  md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+    const href = tokens[idx].attrGet('href') ?? ''
+    if (/^https?:/.test(href)) {
+      tokens[idx].attrSet('target', '_blank')
+      tokens[idx].attrSet('rel', 'noopener noreferrer')
+    }
+    return defaultLinkRender(tokens, idx, options, env, self)
+  }
+
+  mdInstance = md
+  return md
+}
+
+export interface RenderResult {
+  html: string
+  /** Word count → reading time in minutes (200 wpm, floored at 1). */
+  readingTimeMinutes: number
+}
+
+export async function renderMarkdown(content: string): Promise<RenderResult> {
+  const md = await getRenderer()
+  const html = md.render(content || '')
+  const words = (content || '').trim().split(/\s+/).filter(Boolean).length
+  const minutes = Math.max(1, Math.ceil(words / 200))
+  return { html, readingTimeMinutes: minutes }
+}


### PR DESCRIPTION
## Summary

Live the bilingual blog. Pulls from the new `/v1/public/posts/*` endpoints in rb_management_api (#103 — merged) via a server-side proxy that injects `X-Tenant-ID` from Helm/Vault. Pages are pre-rendered with Nitro SWR so visitors get instant HTML and the home auto-refreshes when a new post publishes — no manual rebuild.

## What's in
- **Server proxy** `/api/blog/[...]` → `<BLOG_API_URL>/v1/public/posts/...` with X-Tenant-ID injected, cache headers passed through, 304 short-circuit
- **Markdown renderer** server-side (markdown-it + shiki dual-theme github-dark/light) so highlighted HTML reaches the browser without the 7MB Shiki grammar
- **Composable** `useBlog()` with `getLatest`, `getList`, `getBySlug`, `getTags`, `registerView`
- **Pages**:
  - `pages/blog/index.vue` + `pages/en/blog/index.vue`
  - `pages/blog/[slug].vue` + `pages/en/blog/[slug].vue`
  - `pages/index.vue` gets `<BlogLatestPosts lang="pt-BR" :limit="3" />` between Projetos and Experience (`#blog` anchor in MainHeader nav)
- **Components** (`components/blog/`): BlogCard, BlogTagPill, BlogShareButtons, BlogSearchBar, BlogList, BlogArticle, LatestPosts, MarkdownContent — terminal/mono aesthetic
- **SEO**: per-article `useSeoMeta` + JSON-LD `BlogPosting` + hreflang PT↔EN cross-links + dynamic `sitemap.xml` with bilingual `<xhtml:link rel="alternate">` per post
- **Nuxt config**: removed legacy `target: 'static'`, added `nitro.routeRules` with SWR (300s for lists, 600s for detail/home)

## How the deploy works
This PR is **for staging only**. CI's `cd.yml` only fires on merge to `main`. Once this PR is opened, I'll trigger `deploy-staging.yml` via `workflow_dispatch` so the branch lands on `https://rodolfodebonis.stg.rb.lab`. Smoke-test there before merging to main (which then auto-publishes to prod).

## Env vars to set in stg
- `BLOG_API_URL` — defaults to `https://api.management.rodolfodebonis.com.br`
- `BLOG_TENANT_ID` — required; the public blog proxy 503s if unset

## Test plan
- [ ] Trigger `deploy-staging.yml` and wait for ArgoCD sync to `portfolio-stg`
- [ ] `https://rodolfodebonis.stg.rb.lab/` renders home with `04. Últimas Postagens` section
- [ ] `https://rodolfodebonis.stg.rb.lab/blog` lists published posts; tag chips filter; search uses upstream tsvector
- [ ] `https://rodolfodebonis.stg.rb.lab/blog/<slug>` renders Markdown with Shiki highlighting (test code block in dark + light)
- [ ] `https://rodolfodebonis.stg.rb.lab/en/blog/<en-slug>` shows EN copy + `<link rel="alternate" hreflang="pt-BR">` cross-link
- [ ] `curl /sitemap.xml` returns valid XML with hreflang annotations per post
- [ ] `curl /robots.txt` references the sitemap
- [ ] View counter increments after first article load (Redis dedup blocks repeats within 24h)
- [ ] `Cache-Control` + `ETag` round-trip — re-request with `If-None-Match` returns 304