### PR TITLE
feat(analytics): add Google Tag Manager

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -87,6 +87,21 @@ export default defineNuxtConfig({
           href: '/apple-touch-icon.png',
         },
       ],
+      script: [
+        {
+          innerHTML: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-PKXGMS9W');`,
+        },
+      ],
+      noscript: [
+        {
+          innerHTML: `<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PKXGMS9W" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
+          tagPosition: 'bodyOpen',
+        },
+      ],
     },
   },
 


### PR DESCRIPTION
## Summary
- Adds Google Tag Manager container `GTM-PKXGMS9W` to the site via `app.head` in `nuxt.config.js`.
- GTM loader runs as an inline `<script>` in `<head>`; the fallback `<noscript><iframe>` is injected at `tagPosition: 'bodyOpen'` so it lands right after `<body>`, per Google's docs.
- No new dependencies, no runtime config — single-file change.

## Test plan
- [x] `npm run dev` and confirm `localhost:3030` returns 200.
- [x] Page HTML contains the GTM loader inside `<head>` and the `<noscript>` iframe immediately after `<body>` (verified via `curl`).
- [ ] After deploy: open the site, DevTools → Network shows request to `https://www.googletagmanager.com/gtm.js?id=GTM-PKXGMS9W` (200).
- [ ] In GA4 Realtime (if a GA4 tag is wired inside the GTM container), the test session shows up within ~30s.