### PR TITLE
fix(i18n): corrige Experience render e troca de idioma no Blog

### DIFF
--- a/components/Experience.vue
+++ b/components/Experience.vue
@@ -75,7 +75,7 @@
 <script setup>
 import { experienceMeta } from '~/data/experience'
 
-const { t, tm, locale } = useI18n()
+const { t, tm, rt, locale } = useI18n()
 
 // timeline rebuilds the period string from periodStart/periodEnd in
 // the locale ("2017") + the localised `periodCurrent` label
@@ -93,10 +93,10 @@ const timeline = computed(() => {
       const periodEnd = meta.current ? currentLabel : item.periodEnd ?? currentLabel
       return {
         id: item.id,
-        period: `${item.periodStart} – ${periodEnd}`,
-        title: item.title,
-        description: item.description,
-        achievements: item.achievements ?? [],
+        period: `${rt(item.periodStart)} – ${rt(periodEnd)}`,
+        title: rt(item.title),
+        description: rt(item.description),
+        achievements: (item.achievements ?? []).map((a) => rt(a)),
         current: !!meta.current,
         tags: meta.tags ?? [],
       }

--- a/components/MainHeader.vue
+++ b/components/MainHeader.vue
@@ -90,6 +90,7 @@
 <script setup>
 const colorMode = useColorMode()
 const route = useRoute()
+const router = useRouter()
 const menuOpen = ref(false)
 const isDark = computed(() => colorMode.value === 'dark')
 
@@ -122,7 +123,7 @@ function toggleTheme() {
   colorMode.preference = isDark.value ? 'light' : 'dark'
 }
 
-function onLanguageSwitch() {
+async function onLanguageSwitch() {
   const next = locale.value === 'en' ? 'pt-BR' : 'en'
   // GTM hook so we can attribute future engagement deltas to language
   // preference. Wrap in client-only check so SSR doesn't blow up on
@@ -130,7 +131,22 @@ function onLanguageSwitch() {
   if (typeof window !== 'undefined' && Array.isArray(window.dataLayer)) {
     window.dataLayer.push({ event: 'language_change', language: next })
   }
-  setLocale(next)
+
+  const path = route.path
+  const isBlogPath = path === '/blog' || path.startsWith('/blog/') || path === '/en/blog' || path.startsWith('/en/blog/')
+
+  if (isBlogPath) {
+    const targetPath = next === 'en'
+      ? (path.startsWith('/en') ? path : `/en${path}`)
+      : path.replace(/^\/en/, '') || '/'
+
+    await setLocale(next)
+    await router.push(targetPath)
+    menuOpen.value = false
+    return
+  }
+
+  await setLocale(next)
   menuOpen.value = false
 }
 </script>


### PR DESCRIPTION
## O que corrige\n\n- Corrige renderização da seção Experience que estava exibindo objetos i18n (`[object Object]` / AST) em vez de texto\n- Corrige troca de idioma quando usuário está em rotas do blog (`/blog` ↔ `/en/blog`)\n\n## Detalhes técnicos\n\n### 1) Experience\n- Em `components/Experience.vue` adicionado `rt` do `useI18n()`\n- Campos vindos de `tm('experience.timeline')` agora são normalizados com `rt(...)`:\n  - `title`\n  - `description`\n  - `periodStart/periodEnd`\n  - itens de `achievements`\n\n### 2) Header language switch no Blog\n- Em `components/MainHeader.vue` adicionado `useRouter()`\n- `onLanguageSwitch` agora detecta se a rota atual é de blog e faz mapeamento explícito:\n  - PT → EN: prefixa `/en`\n  - EN → PT: remove prefixo `/en`\n- Mantém `setLocale(next)`, e em rotas de blog faz `router.push(targetPath)` para garantir navegação correta\n\n## Resultado esperado\n\n- Seção Experience renderiza texto normal em ambos idiomas\n- Troca de idioma no blog passa a navegar corretamente entre as rotas equivalentes\n