### PR TITLE
fix(i18n): corrige Featured Projects vazio e locale do bloco Latest Posts

### DIFF
--- a/components/Projects.vue
+++ b/components/Projects.vue
@@ -84,7 +84,7 @@
 <script setup>
 import { projectsMeta } from '~/data/projects'
 
-const { t, tm, locale } = useI18n()
+const { t, tm, rt, locale } = useI18n()
 
 // projects merges the locale-specific copy (title, description,
 // highlights) with the locale-neutral meta (image, tags, githubUrl).
@@ -101,13 +101,14 @@ const projects = computed(() => {
   const byId = new Map(projectsMeta.map((p) => [p.id, p]))
   return localized
     .map((item) => {
-      const meta = byId.get(item.id)
+      const itemId = rt(item.id)
+      const meta = byId.get(itemId)
       if (!meta) return null
       return {
-        id: item.id,
-        title: item.title,
-        description: item.description,
-        highlights: item.highlights ?? [],
+        id: itemId,
+        title: rt(item.title),
+        description: rt(item.description),
+        highlights: (item.highlights ?? []).map((h) => rt(h)),
         image: meta.image,
         tags: meta.tags,
         githubUrl: meta.githubUrl,

--- a/components/blog/LatestPosts.vue
+++ b/components/blog/LatestPosts.vue
@@ -6,17 +6,17 @@
         <div>
           <div class="flex items-center gap-3 mb-4">
             <span class="mono text-[var(--accent)] text-sm">04.</span>
-            <h2 class="text-3xl md:text-4xl font-bold">Últimas Postagens</h2>
+            <h2 class="text-3xl md:text-4xl font-bold">{{ copy.title }}</h2>
           </div>
           <p class="text-[var(--text-muted)] max-w-2xl">
-            Notas técnicas, postmortems e experimentos.
+            {{ copy.description }}
           </p>
         </div>
         <NuxtLink
-          to="/blog"
+          :to="copy.blogPath"
           class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border)] text-sm mono text-[var(--text-primary)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
         >
-          Ver todos
+          {{ copy.cta }}
           <span class="material-icons text-base">arrow_forward</span>
         </NuxtLink>
       </div>
@@ -54,6 +54,7 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useAsyncData } from 'nuxt/app'
 import { useBlog, type Lang, type BlogPost } from '~/composables/useBlog'
 
@@ -68,14 +69,31 @@ const props = withDefaults(
   },
 )
 
+const copy = computed(() =>
+  props.lang === 'en'
+    ? {
+        title: 'Latest Posts',
+        description: 'Technical notes, postmortems, and experiments.',
+        cta: 'View all',
+        blogPath: '/en/blog',
+      }
+    : {
+        title: 'Últimas Postagens',
+        description: 'Notas técnicas, postmortems e experimentos.',
+        cta: 'Ver todos',
+        blogPath: '/blog',
+      },
+)
+
 const { data: posts, pending, error } = await useAsyncData<BlogPost[]>(
-  `blog-latest-${props.lang}-${props.limit}`,
+  () => `blog-latest-${props.lang}-${props.limit}`,
   () => useBlog().getLatest(props.lang, props.limit),
   {
     // Re-fetch when the home page revalidates (SWR handles this at the
     // route level; keep the composable cache-friendly).
     server: true,
     lazy: false,
+    watch: [() => props.lang, () => props.limit],
     default: () => [],
   },
 )


### PR DESCRIPTION
## Problemas\n\n1. **Featured Projects vazio no EN**\n   -  retornava mensagens estruturadas e os campos eram usados sem normalização.\n   - O uid=1000(openclaw) gid=1000(openclaw) groups=1000(openclaw),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),101(lxd),988(docker) não batia no mapa , resultando em todos os itens filtrados.\n\n2. **Bloco Latest Posts em PT no EN**\n   -  tinha textos e link hardcoded em português (, , ).\n\n## Correções\n\n### Projects.vue\n- Adicionado  no \n- Normalização com  para:\n  - uid=1000(openclaw) gid=1000(openclaw) groups=1000(openclaw),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),101(lxd),988(docker)\n  - \n  - \n  - \n\n### LatestPosts.vue\n- Removido hardcode em PT\n- Adicionado  computado por :\n  - EN: , , \n  - PT: , , \n- Chave do  virou função reativa\n- Adicionado  em  e  para refetch correto\n\n## Resultado esperado\n\n- Cards de Featured Projects voltam a aparecer no EN\n- Bloco Latest Posts respeita idioma e link corretos\n