### PR TITLE
fix(blog): corrige 404 no EN quando slug pertence ao PT

### DIFF
--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -74,12 +74,16 @@ const translation = computed(() => pickTranslation(props.post, lang.value))
 const title = computed(() => translation.value?.title ?? '—')
 const excerpt = computed(() => translation.value?.excerpt ?? '')
 
-// Build the link for the appropriate language. Falls back to slug from
-// any available translation when the requested lang isn't present.
+// Build the link using the translation that actually provided the slug.
+// If EN is missing, we fall back to PT route (/blog/...) instead of
+// incorrectly forcing /en/blog/... with a PT slug.
 const link = computed(() => {
-  const slug = translation.value?.slug ?? props.post.translations?.[0]?.slug
+  const selected = props.post.translations?.find((t) => t.lang === lang.value)
+  const fallback = props.post.translations?.find((t) => t.lang === 'pt-BR') ?? props.post.translations?.[0]
+  const target = selected ?? fallback
+  const slug = target?.slug
   if (!slug) return '/blog'
-  return lang.value === 'en' ? `/en/blog/${slug}` : `/blog/${slug}`
+  return target?.lang === 'en' ? `/en/blog/${slug}` : `/blog/${slug}`
 })
 
 const formattedDate = computed(() => {


### PR DESCRIPTION
## Problema\n\nNo card do blog, quando faltava tradução EN para um post, o link fazia fallback de slug para outra tradução (geralmente PT), mas mantinha prefixo EN ().\n\nIsso gerava 404 / "post não encontrado" ao abrir o artigo em inglês.\n\n## Correção\n\n- Em , o link agora:\n  1. tenta tradução no idioma atual\n  2. fallback para  (ou primeira disponível)\n  3. monta a rota com base no idioma da tradução selecionada\n     - EN slug -> \n     - PT slug -> \n\n## Resultado\n\n- Evita URL EN inválida com slug PT\n- Usuário sempre cai numa versão existente do artigo\n