### PR TITLE
feat(blog): like toggle for posts and comments

### DIFF
--- a/components/blog/BlogArticle.vue
+++ b/components/blog/BlogArticle.vue
@@ -49,7 +49,7 @@
         >
           {{ authorInitials }}
         </div>
-        <div class="flex flex-col text-sm">
+        <div class="flex flex-col text-sm flex-1">
           <span class="font-medium text-[var(--text-primary)]">{{ authorName }}</span>
           <span class="mono text-xs text-[var(--text-muted)]">
             {{ formattedDate }} · {{ data.reading_time_minutes }} min
@@ -58,6 +58,19 @@
             </template>
           </span>
         </div>
+        <button
+          type="button"
+          class="like-button"
+          :class="{ 'is-liked': liked }"
+          :aria-pressed="liked"
+          :aria-label="liked ? copy.unlike : copy.like"
+          :title="liked ? copy.unlike : copy.like"
+          :disabled="likeBusy"
+          @click="onLikeClick"
+        >
+          <i :class="liked ? 'mdi mdi-heart' : 'mdi mdi-heart-outline'"></i>
+          <span class="like-button__count">{{ likeCount }}</span>
+        </button>
       </div>
 
       <!-- Cover -->
@@ -113,7 +126,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useAsyncData, useHead, useSeoMeta } from 'nuxt/app'
 import {
   pickTranslation,
@@ -130,8 +143,18 @@ const props = defineProps<{
 
 const copy = computed(() =>
   props.lang === 'en'
-    ? { notFound: 'post not found', backToBlog: 'back to blog' }
-    : { notFound: 'post não encontrado', backToBlog: 'voltar para o blog' },
+    ? {
+        notFound: 'post not found',
+        backToBlog: 'back to blog',
+        like: 'Like this post',
+        unlike: 'Unlike this post',
+      }
+    : {
+        notFound: 'post não encontrado',
+        backToBlog: 'voltar para o blog',
+        like: 'Curtir post',
+        unlike: 'Descurtir post',
+      },
 )
 
 const { data, error } = await useAsyncData<{
@@ -332,8 +355,92 @@ useHead({
   },
 })
 
-// Best-effort view tracker (fire-and-forget).
-onMounted(() => {
-  useBlog().registerView(props.slug, props.lang)
+// Likes — render from the SSR payload, then hydrate the per-IP `liked`
+// flag on mount. The SSR response never sends X-Reader-State so the
+// shared cache stays usable; the authoritative flag arrives one
+// round-trip later via fetchReaderState.
+const likeCount = ref(data.value?.post?.like_count ?? 0)
+const liked = ref(false)
+const likeBusy = ref(false)
+// Keep the count in sync if the SSR payload swaps (route change between
+// posts without a full reload).
+watch(
+  () => data.value?.post?.like_count,
+  (next) => {
+    if (typeof next === 'number') likeCount.value = next
+  },
+)
+
+async function onLikeClick() {
+  if (likeBusy.value) return
+  likeBusy.value = true
+  // Optimistic — invert + adjust count so the heart fills instantly.
+  // Reconcile with the server response below; on error roll back.
+  const prevLiked = liked.value
+  const prevCount = likeCount.value
+  liked.value = !prevLiked
+  likeCount.value = Math.max(0, prevCount + (liked.value ? 1 : -1))
+  try {
+    const res = await useBlog().likePost(props.slug, props.lang)
+    liked.value = res.liked
+    likeCount.value = res.like_count
+  } catch {
+    liked.value = prevLiked
+    likeCount.value = prevCount
+  } finally {
+    likeBusy.value = false
+  }
+}
+
+// Best-effort view tracker (fire-and-forget) + authoritative liked flag.
+onMounted(async () => {
+  const blog = useBlog()
+  blog.registerView(props.slug, props.lang)
+  try {
+    const state = await blog.fetchReaderState(props.slug, props.lang)
+    liked.value = state.liked
+    likeCount.value = state.like_count
+  } catch {
+    // Reader-state hydration is best-effort: the UI stays at the SSR
+    // count + liked=false. The server is still the source of truth on
+    // click (POST returns the canonical state).
+  }
 })
 </script>
+
+<style scoped>
+.like-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border-radius: 9999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.75rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+.like-button:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.like-button:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+.like-button.is-liked {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.like-button .mdi {
+  font-size: 1rem;
+  line-height: 1;
+}
+.like-button__count {
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -53,6 +53,13 @@
           <span class="material-icons text-[12px]">visibility</span>
           {{ formatViews(post.view_count) }}
         </span>
+        <template v-if="(post.like_count ?? 0) > 0">
+          <span>·</span>
+          <span class="flex items-center gap-1">
+            <i class="mdi mdi-heart-outline" style="font-size:12px;line-height:1"></i>
+            {{ formatViews(post.like_count) }}
+          </span>
+        </template>
       </div>
     </div>
   </NuxtLink>

--- a/components/blog/CommentItem.vue
+++ b/components/blog/CommentItem.vue
@@ -45,6 +45,19 @@
       >
         {{ flagged ? t.flagged : t.flag }}
       </button>
+      <button
+        type="button"
+        class="comment__action comment__action--like"
+        :class="{ 'is-liked': liked }"
+        :aria-pressed="liked"
+        :aria-label="liked ? t.unlike : t.like"
+        :title="liked ? t.unlike : t.like"
+        :disabled="likeBusy"
+        @click="onLike"
+      >
+        <i :class="liked ? 'mdi mdi-heart' : 'mdi mdi-heart-outline'"></i>
+        <span v-if="likeCount > 0" class="comment__like-count">{{ likeCount }}</span>
+      </button>
     </footer>
 
     <!-- Inline edit textarea — only visible to the original author
@@ -129,6 +142,12 @@ const saving = ref(false)
 const editError = ref('')
 const flagging = ref(false)
 const flagged = ref(false)
+// Like state is hydrated from the comment payload (the thread fetch
+// opts into X-Reader-State so each node already carries `liked`).
+// Click handler reconciles with the server's authoritative response.
+const liked = ref(props.comment.liked === true)
+const likeCount = ref(props.comment.like_count ?? 0)
+const likeBusy = ref(false)
 
 const canEdit = computed(() =>
   comments.canEdit(props.comment.id) && isWithinEditWindow(props.comment.created_at),
@@ -166,6 +185,25 @@ async function onFlag() {
   }
 }
 
+async function onLike() {
+  if (likeBusy.value) return
+  likeBusy.value = true
+  const prevLiked = liked.value
+  const prevCount = likeCount.value
+  liked.value = !prevLiked
+  likeCount.value = Math.max(0, prevCount + (liked.value ? 1 : -1))
+  try {
+    const res = await comments.like(props.comment.id)
+    liked.value = res.liked
+    likeCount.value = res.like_count
+  } catch {
+    liked.value = prevLiked
+    likeCount.value = prevCount
+  } finally {
+    likeBusy.value = false
+  }
+}
+
 function onReplySubmitted(c: BlogComment) {
   showReply.value = false
   emit('reply-added', c)
@@ -181,6 +219,8 @@ const t = {
     saving: 'Salvando…',
     flag: '🚩 Reportar',
     flagged: '✓ Reportado',
+    like: 'Curtir',
+    unlike: 'Descurtir',
     removed: '[comentário removido]',
     edited: 'editado',
   },
@@ -193,6 +233,8 @@ const t = {
     saving: 'Saving…',
     flag: '🚩 Report',
     flagged: '✓ Reported',
+    like: 'Like',
+    unlike: 'Unlike',
     removed: '[comment removed]',
     edited: 'edited',
   },
@@ -254,6 +296,23 @@ const t = {
 }
 .comment__action--danger:hover {
   color: #ef4444;
+}
+.comment__action--like {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: auto;
+}
+.comment__action--like .mdi {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+.comment__action--like.is-liked {
+  color: var(--accent);
+}
+.comment__like-count {
+  font-family: 'JetBrains Mono', monospace;
+  font-variant-numeric: tabular-nums;
 }
 .comment__edit {
   margin-top: 0.5rem;

--- a/composables/useBlog.ts
+++ b/composables/useBlog.ts
@@ -54,6 +54,13 @@ export interface BlogPost {
   og_image_url?: string
   reading_time_minutes: number
   view_count: number
+  like_count: number
+  /**
+   * Reader-state field — present only when the request opted in via
+   * `X-Reader-State: true`. Initial SSR fetch leaves this `undefined`
+   * to keep the response cacheable; the client hydrates it on mount.
+   */
+  liked?: boolean
   featured: boolean
   created_at: string
   updated_at: string
@@ -123,6 +130,49 @@ export function useBlog() {
       }).catch(() => {
         /* silent */
       })
+    },
+
+    /**
+     * Toggle a like on the post. Same IP that already liked → -1 and
+     * `liked: false`; new IP → +1 and `liked: true`. Rate-limited
+     * 30/min/IP upstream so a burst of click-spam degrades to 429
+     * before the dedup table is touched.
+     */
+    async likePost(
+      slug: string,
+      lang: Lang = 'pt-BR',
+    ): Promise<{ liked: boolean; like_count: number }> {
+      return $fetch<{ liked: boolean; like_count: number }>(
+        `/api/blog/posts/by-slug/${slug}/like`,
+        {
+          method: 'POST',
+          query: { lang },
+        },
+      )
+    },
+
+    /**
+     * Hydrate the per-reader liked flag for an already-rendered post.
+     * Called once on mount — SSR omits the X-Reader-State header so
+     * the shared cache stays usable, then the client follows up with
+     * this dedicated authoritative fetch. Returns just the fields the
+     * UI needs; ignores the rest of the (already-rendered) post body.
+     */
+    async fetchReaderState(
+      slug: string,
+      lang: Lang = 'pt-BR',
+    ): Promise<{ liked: boolean; like_count: number }> {
+      const post = await $fetch<BlogPost>(
+        `/api/blog/posts/by-slug/${slug}`,
+        {
+          query: { lang },
+          headers: { 'X-Reader-State': 'true' },
+        },
+      )
+      return {
+        liked: post.liked === true,
+        like_count: post.like_count ?? 0,
+      }
     },
   }
 }

--- a/composables/useComments.ts
+++ b/composables/useComments.ts
@@ -28,6 +28,13 @@ export interface BlogComment {
   body_html: string
   status: CommentStatus
   flag_count?: number
+  like_count: number
+  /**
+   * Reader-state field — populated only when the request opted in via
+   * `X-Reader-State: true`. The thread fetch below always opts in
+   * (comments aren't SSR-cached), so this is reliable on the client.
+   */
+  liked?: boolean
   edited_at?: string | null
   created_at: string
   updated_at: string
@@ -58,10 +65,17 @@ const editTokenStorageKey = (id: string) => `blog:comment:${id}:edit_token`
 
 export function useComments() {
   return {
-    /** Fetch the comment tree for a published post (by slug + lang). */
+    /**
+     * Fetch the comment tree for a published post (by slug + lang).
+     * Always sends `X-Reader-State: true` so each node carries the
+     * per-IP `liked` flag — comments are never SSR-cached (proxy has
+     * `cache: false` for /api/blog/**), so opting in here costs
+     * nothing extra and saves a separate round-trip.
+     */
     async getByPostSlug(slug: string, lang: 'pt-BR' | 'en' = 'pt-BR'): Promise<BlogComment[]> {
       return $fetch<BlogComment[]>(`/api/blog/posts/${slug}/comments`, {
         query: { lang },
+        headers: { 'X-Reader-State': 'true' },
       })
     },
 
@@ -107,6 +121,18 @@ export function useComments() {
       return $fetch<{ flag_count: number; duplicate: boolean }>(`/api/blog/comments/${id}/flag`, {
         method: 'POST',
         body: input,
+      })
+    },
+
+    /**
+     * Toggle a like on a comment. Same IP that already liked → -1 and
+     * `liked: false`; new IP → +1 and `liked: true`. Rate-limited
+     * 30/min/IP upstream — UNIQUE on (comment_id, ip_hash) is the
+     * authoritative dedup.
+     */
+    async like(id: string): Promise<{ liked: boolean; like_count: number }> {
+      return $fetch<{ liked: boolean; like_count: number }>(`/api/blog/comments/${id}/like`, {
+        method: 'POST',
       })
     },
 

--- a/server/api/blog/[...path].ts
+++ b/server/api/blog/[...path].ts
@@ -28,6 +28,8 @@ import { $fetch, FetchError } from 'ofetch'
  *   GET  /api/blog/posts/latest                 → /v1/public/posts/latest
  *   GET  /api/blog/posts/by-slug/:slug          → /v1/public/posts/by-slug/:slug
  *   POST /api/blog/posts/by-slug/:slug/view     → /v1/public/posts/by-slug/:slug/view
+ *   POST /api/blog/posts/by-slug/:slug/like     → /v1/public/posts/by-slug/:slug/like
+ *   POST /api/blog/comments/:id/like            → /v1/public/comments/:id/like
  *   GET  /api/blog/tags                         → /v1/public/tags
  *
  * Cache passthrough: relays the upstream Cache-Control + ETag so the
@@ -75,9 +77,16 @@ export default defineEventHandler(async (event) => {
   if (incomingHeaders['if-none-match']) {
     forward['If-None-Match'] = incomingHeaders['if-none-match']
   }
-  // Use the real client IP for view dedup keying upstream.
+  // Use the real client IP for view + like dedup keying upstream.
   if (incomingHeaders['x-forwarded-for']) {
     forward['X-Forwarded-For'] = incomingHeaders['x-forwarded-for']
+  }
+  // Forward the reader-state opt-in so BySlug and the comment thread
+  // can return per-reader `liked` flags. Upstream downgrades
+  // Cache-Control to private,no-store when this is present, so the
+  // shared cache never sees IP-specific responses.
+  if (incomingHeaders['x-reader-state']) {
+    forward['X-Reader-State'] = incomingHeaders['x-reader-state']
   }
 
   let body: Record<string, unknown> | undefined


### PR DESCRIPTION
## Summary

Public reader integration of the like feature shipped in rb_management_api#151 and rb_management_web#18.

- Post detail (`BlogArticle.vue`): heart button next to the author/meta line. SSR renders without `X-Reader-State` (keeps the page cacheable); client mount fetches the authoritative `liked` flag in one follow-up request. Click toggles optimistically and reconciles with the server's `{liked, like_count}`.
- Comments (`CommentItem.vue`): heart aligned to the right of every comment row (incl. replies). The thread fetch always opts into `X-Reader-State: true` (comments aren't SSR-cached).
- Blog list (`BlogCard.vue`): read-only `like_count` + outlined heart next to views in the meta strip.
- Nitro proxy (`server/api/blog/[...path].ts`): whitelist `X-Reader-State` so it reaches the upstream.

## Why

Public engagement signal that mirrors the existing view tracker + comment flag flows. No new infra — same anonymous IP-hash dedup the comments module already uses.

## Test plan

- [x] `pnpm build` — Nuxt build succeeds.
- [x] `nuxi typecheck` clean.
- [ ] After merge + deploy:
  - `/blog/<slug>`: heart starts outlined; click fills + count +1; reload, heart stays filled (server confirmed via X-Reader-State).
  - Click again → outlined + -1.
  - Comment heart: same behaviour, scoped per comment.
  - `/blog`: cards show heart + count read-only when `like_count > 0`.
  - DevTools: 2 requests to BySlug on detail (SSR + reader-state); thread fetch carries `X-Reader-State: true`.

## Depends on

- rb_management_api#151 (deployed, v3.9.9)
- rb_management_web#18 (merged)