### PR TITLE
fix(blog): like icon uses Material Icons ligature, not MDI classes

### DIFF
--- a/components/blog/BlogArticle.vue
+++ b/components/blog/BlogArticle.vue
@@ -68,7 +68,9 @@
           :disabled="likeBusy"
           @click="onLikeClick"
         >
-          <i :class="liked ? 'mdi mdi-heart' : 'mdi mdi-heart-outline'"></i>
+          <span class="material-icons like-button__icon">
+            {{ liked ? 'favorite' : 'favorite_border' }}
+          </span>
           <span class="like-button__count">{{ likeCount }}</span>
         </button>
       </div>
@@ -436,7 +438,7 @@ onMounted(async () => {
   color: var(--accent);
   border-color: var(--accent);
 }
-.like-button .mdi {
+.like-button__icon {
   font-size: 1rem;
   line-height: 1;
 }

--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -56,7 +56,7 @@
         <template v-if="(post.like_count ?? 0) > 0">
           <span>·</span>
           <span class="flex items-center gap-1">
-            <i class="mdi mdi-heart-outline" style="font-size:12px;line-height:1"></i>
+            <span class="material-icons text-[12px]">favorite_border</span>
             {{ formatViews(post.like_count) }}
           </span>
         </template>

--- a/components/blog/CommentItem.vue
+++ b/components/blog/CommentItem.vue
@@ -55,7 +55,9 @@
         :disabled="likeBusy"
         @click="onLike"
       >
-        <i :class="liked ? 'mdi mdi-heart' : 'mdi mdi-heart-outline'"></i>
+        <span class="material-icons comment__like-icon">
+          {{ liked ? 'favorite' : 'favorite_border' }}
+        </span>
         <span v-if="likeCount > 0" class="comment__like-count">{{ likeCount }}</span>
       </button>
     </footer>
@@ -303,8 +305,8 @@ const t = {
   gap: 0.25rem;
   margin-left: auto;
 }
-.comment__action--like .mdi {
-  font-size: 0.95rem;
+.comment__like-icon {
+  font-size: 0.95rem !important;
   line-height: 1;
 }
 .comment__action--like.is-liked {


### PR DESCRIPTION
## Summary

PR #303 used MDI class names (`mdi mdi-heart`) for the like icons, but the portfolio loads Google's Material Icons font (the `material-icons` class + ligature) — `@mdi/font` isn't installed. Result: empty space where the heart should be (post detail meta line + comment heart pill).

Fix: use the existing convention `<span class="material-icons">favorite</span>` (filled) and `favorite_border` (outlined). Same files as #303, no other change.

## Test plan

- [x] `pnpm build` — clean.
- [ ] After deploy: heart actually shows on `/blog/<slug>`, comment thread, and `/blog` list card.