### PR TITLE
feat(portfolio): hero terminal commands come from the CMS

### DIFF
--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -177,7 +177,10 @@ const stackPreview = computed(() => {
 })
 
 const terminalLine = ref(null)
-const commands = [
+// Terminal commands come from the CMS now. The fallback array keeps
+// the animation visible if the public profile fetch failed on a cold
+// render or the admin emptied the list — better than a blank panel.
+const fallbackCommands = [
   'kubectl get pods --all-namespaces',
   'go build -o server ./cmd/api',
   'docker compose up -d',
@@ -185,6 +188,10 @@ const commands = [
   'terraform apply -auto-approve',
   'flutter run --release',
 ]
+const commands = computed(() => {
+  const cms = profile.value?.terminal_commands
+  return cms && cms.length > 0 ? cms : fallbackCommands
+})
 
 let cmdIdx = 0
 let charIdx = 0
@@ -194,8 +201,8 @@ const delayBetween = 2500
 
 function typeEffect() {
   if (!terminalLine.value) return
-  if (charIdx < commands[cmdIdx].length) {
-    terminalLine.value.textContent += commands[cmdIdx].charAt(charIdx)
+  if (charIdx < commands.value[cmdIdx].length) {
+    terminalLine.value.textContent += commands.value[cmdIdx].charAt(charIdx)
     charIdx++
     setTimeout(typeEffect, typeSpeed)
   } else {
@@ -206,11 +213,11 @@ function typeEffect() {
 function eraseEffect() {
   if (!terminalLine.value) return
   if (charIdx > 0) {
-    terminalLine.value.textContent = commands[cmdIdx].substring(0, charIdx - 1)
+    terminalLine.value.textContent = commands.value[cmdIdx].substring(0, charIdx - 1)
     charIdx--
     setTimeout(eraseEffect, eraseSpeed)
   } else {
-    cmdIdx = (cmdIdx + 1) % commands.length
+    cmdIdx = (cmdIdx + 1) % commands.value.length
     setTimeout(typeEffect, 500)
   }
 }

--- a/composables/usePortfolio.ts
+++ b/composables/usePortfolio.ts
@@ -27,6 +27,8 @@ export interface PortfolioProfile {
   location_city?: string
   location_region?: string
   location_country?: string
+  /** Shell-looking strings cycled in the Hero's terminal animation. */
+  terminal_commands?: string[]
   // Translated fields — flattened by the API for the requested lang.
   headline?: string
   subtitle?: string


### PR DESCRIPTION
## Summary

The Hero's terminal animation cycled a hardcoded array of six commands. The list is now a profile field on the CMS (\`terminal_commands TEXT[]\`) so the admin can edit it without touching code.

- \`PortfolioProfile\` gains optional \`terminal_commands\`.
- \`Hero.vue\` reads \`profile.terminal_commands\`; falls back to the legacy array when the CMS payload is missing or empty so the animation never goes blank on a cold render.

## Test plan

- [x] \`pnpm build\` clean.
- [ ] After deploy: edit terminal_commands in the admin → new list shows on the public site within 10 min (SWR window).

## Depends on

- rb_management_api #153 (merged) — exposes \`terminal_commands\` on the profile.
- rb_management_web #20 (merged) — admin form to edit it.