### PR TITLE
feat(portfolio): preview mode (cookie + banner + routes)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__plugin_figma_figma__use_figma",
+      "mcp__plugin_figma_figma__get_screenshot",
+      "Bash(curl -sS -o /tmp/v4-03-create.png \"https://www.figma.com/api/mcp/asset/19fdac51-d1ba-442e-ab9f-7d3193da98a7\")",
+      "Bash(curl -sS -o /tmp/v4-04-edit.png \"https://www.figma.com/api/mcp/asset/bc40ed91-187f-4147-aeff-7a84637a1a57\")",
+      "mcp__plugin_figma_figma__whoami",
+      "mcp__plugin_figma_figma__create_new_file",
+      "Bash(curl *)",
+      "Bash(awk '/^\\\\.\\(glow-line|glass|terminal-cursor|section-container|badge\\)\\\\s*\\\\{/,/^\\\\}/' assets/css/main.css)"
+    ]
+  }
+}

--- a/App.vue
+++ b/App.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="min-h-screen bg-[var(--bg-primary)] text-[var(--text-secondary)] grain">
+    <PreviewBanner />
     <NuxtPage />
   </div>
 </template>

--- a/components/PreviewBanner.vue
+++ b/components/PreviewBanner.vue
@@ -1,0 +1,49 @@
+<template>
+  <Teleport to="body">
+    <aside
+      v-if="active"
+      class="fixed top-0 left-0 right-0 z-[60] bg-[var(--accent)] text-[var(--bg-primary)] shadow-lg"
+    >
+      <div class="section-container py-2 flex items-center justify-between gap-4 text-sm mono">
+        <div class="flex items-center gap-2 truncate">
+          <span class="material-icons text-base">visibility</span>
+          <span class="font-semibold uppercase tracking-wider text-xs">preview</span>
+          <span class="truncate">{{ message }}</span>
+        </div>
+        <a
+          href="/preview/exit"
+          class="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wider hover:underline shrink-0"
+        >
+          {{ exitLabel }}
+          <span class="material-icons text-sm">logout</span>
+        </a>
+      </div>
+    </aside>
+  </Teleport>
+</template>
+
+<script setup>
+import { useRequestEvent } from 'nuxt/app'
+
+// Active is decided server-side from the cookie. We render the banner
+// during SSR so it shows on first paint without a hydration flicker.
+// Reading via useRequestEvent keeps the cookie httpOnly (never reaches
+// the browser-side script).
+const event = useRequestEvent()
+const cookieValue = computed(() => {
+  if (!event) return null
+  const cookie = event.node.req.headers?.cookie ?? ''
+  const match = cookie.match(/(?:^|;\s*)preview_token=([^;]+)/)
+  return match ? decodeURIComponent(match[1]) : null
+})
+
+const active = computed(() => !!cookieValue.value)
+
+const { locale } = useI18n()
+const message = computed(() =>
+  locale.value === 'en'
+    ? 'Drafts visible until your token expires.'
+    : 'Rascunhos visíveis até o token expirar.',
+)
+const exitLabel = computed(() => (locale.value === 'en' ? 'Exit' : 'Sair'))
+</script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -244,5 +244,7 @@ export default defineNuxtConfig({
     // Same contract for the portfolio CMS proxy — the upstream owns
     // the Cache-Control and Nitro must not cache between revalidations.
     '/api/portfolio/**': { cache: false },
+    // Preview entrypoints set/clear the auth cookie — never cache.
+    '/preview/**': { cache: false, headers: { 'cache-control': 'private, no-store' } },
   },
 })

--- a/server/api/portfolio/[...path].ts
+++ b/server/api/portfolio/[...path].ts
@@ -3,6 +3,7 @@ import {
   getRouterParam,
   getQuery,
   getRequestHeaders,
+  getCookie,
   createError,
   setResponseHeader,
   setResponseStatus,
@@ -58,6 +59,14 @@ export default defineEventHandler(async (event) => {
   }
   if (incomingHeaders['x-forwarded-for']) {
     forward['X-Forwarded-For'] = incomingHeaders['x-forwarded-for']
+  }
+  // Forward the preview cookie as an upstream header so the public
+  // endpoints know to include drafts. The cookie itself is httpOnly
+  // — it never reaches the browser-side composables — but the
+  // server-side proxy is exactly the right place to read it.
+  const previewToken = getCookie(event, 'preview_token')
+  if (previewToken) {
+    forward['X-Preview-Token'] = previewToken
   }
 
   try {

--- a/server/middleware/preview-headers.ts
+++ b/server/middleware/preview-headers.ts
@@ -1,0 +1,16 @@
+import { defineEventHandler, getCookie, setResponseHeader } from 'h3'
+
+/**
+ * When the visitor has a `preview_token` cookie, override the
+ * default Cache-Control so browsers (and downstream CDN proxies
+ * respecting the header) don't serve stale anonymous HTML to a
+ * preview reader. The SWR rule on `/` still caches the upstream
+ * response by URL — that's a known limitation; the upside is the
+ * preview reader's browser stops reusing its local cache once
+ * cookie expires.
+ */
+export default defineEventHandler((event) => {
+  if (getCookie(event, 'preview_token')) {
+    setResponseHeader(event, 'Cache-Control', 'private, no-store')
+  }
+})

--- a/server/routes/preview/exit.ts
+++ b/server/routes/preview/exit.ts
@@ -1,0 +1,11 @@
+import { defineEventHandler, deleteCookie, sendRedirect } from 'h3'
+
+/**
+ * Tears down preview mode: clears the `preview_token` cookie and
+ * sends the visitor back to `/`. Used by the PreviewBanner's "Sair"
+ * button. Idempotent — calling without a cookie is a no-op redirect.
+ */
+export default defineEventHandler(async (event) => {
+  deleteCookie(event, 'preview_token', { path: '/' })
+  return await sendRedirect(event, '/', 302)
+})

--- a/server/routes/preview/start.ts
+++ b/server/routes/preview/start.ts
@@ -1,0 +1,70 @@
+import {
+  defineEventHandler,
+  getQuery,
+  setCookie,
+  sendRedirect,
+  createError,
+} from 'h3'
+import { $fetch } from 'ofetch'
+
+/**
+ * Entrypoint for preview mode. Admins generate a token in the portal
+ * and share the resulting URL (`/preview/start?token=<raw>`) with
+ * reviewers. This handler:
+ *   1. Validates the token against the upstream CMS so the cookie
+ *      lifetime matches the server's actual expiration.
+ *   2. Sets an httpOnly `preview_token` cookie scoped to the same
+ *      max-age.
+ *   3. Redirects to `/` so the visitor sees the homepage with drafts
+ *      surfaced + the PreviewBanner up top.
+ *
+ * Invalid tokens 404. We deliberately avoid revealing whether a
+ * token ever existed (no 401 / no expired marker) — the admin can
+ * re-mint trivially and that signal would just help anyone fuzzing
+ * the surface.
+ */
+export default defineEventHandler(async (event) => {
+  const token = (getQuery(event).token as string | undefined)?.trim()
+  if (!token) {
+    throw createError({ statusCode: 400, message: 'token required' })
+  }
+
+  const baseUrl = (
+    process.env.BLOG_API_URL || 'https://api.management.rodolfodebonis.com.br'
+  ).replace(/\/$/, '')
+  const tenantId = process.env.BLOG_TENANT_ID || ''
+  if (!tenantId) {
+    throw createError({ statusCode: 503, message: 'Preview not configured' })
+  }
+
+  try {
+    const check = await $fetch<{ valid: boolean; expires_at?: string }>(
+      `${baseUrl}/v1/public/portfolio/preview-check`,
+      {
+        query: { token },
+        headers: { 'X-Tenant-ID': tenantId },
+      },
+    )
+    if (!check.valid || !check.expires_at) {
+      throw createError({ statusCode: 404, message: 'invalid token' })
+    }
+    const expiresAt = new Date(check.expires_at)
+    const maxAge = Math.max(
+      1,
+      Math.floor((expiresAt.getTime() - Date.now()) / 1000),
+    )
+    setCookie(event, 'preview_token', token, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      maxAge,
+      path: '/',
+    })
+    return await sendRedirect(event, '/', 302)
+  } catch (err) {
+    if (err && typeof err === 'object' && 'statusCode' in err) {
+      throw err
+    }
+    throw createError({ statusCode: 502, message: 'preview-check unreachable' })
+  }
+})


### PR DESCRIPTION
## Summary

Consumer side of the draft + preview workflow.

- \`/preview/start?token=...\` validates token upstream, sets httpOnly cookie with matching expiration, redirects to \`/\`.
- \`/preview/exit\` clears the cookie + redirects.
- Proxy forwards cookie as \`X-Preview-Token\` upstream.
- Middleware sets \`Cache-Control: private, no-store\` on every cookie-bearing response (browser stops reusing local cache).
- \`PreviewBanner\` SSR teleport at the top of every page when cookie is present.
- Route rule \`/preview/**\` never cached.

## Test plan

- [x] \`pnpm build\` clean.
- [ ] After deploy + admin can issue tokens (depends on \`rb_management_web\` admin merge):
  1. Edit a project to status='draft' in the admin.
  2. Site (\`/\`) doesn't show the draft.
  3. Generate a preview token in \`/portfolio/preview\`.
  4. Open the link in incognito → banner appears + draft is visible.
  5. Click "Sair" → cookie cleared, draft disappears.

## Known limitation

The SWR cache on \`/\` is URL-keyed; a preview reader's first hit may serve a stale anonymous HTML. The \`private, no-store\` header tells the browser to revalidate, but a proper cookie-varying edge cache fix is a follow-up.

## Depends on

- rb_management_api #154 — merged.
- rb_management_web #21 — admin issuance UI (blocked on a billing/CI issue at the moment).