### PR TITLE
feat(blog): per-language cover image with post-level fallback

### DIFF
--- a/components/blog/BlogArticle.vue
+++ b/components/blog/BlogArticle.vue
@@ -77,8 +77,8 @@
 
       <!-- Cover (LCP element on the article route). -->
       <img
-        v-if="data.post.cover_image_url"
-        :src="data.post.cover_image_url"
+        v-if="coverImageUrl"
+        :src="coverImageUrl"
         :alt="translation?.title ?? ''"
         width="1600"
         height="900"
@@ -140,6 +140,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { useAsyncData, useHead, useSeoMeta } from 'nuxt/app'
 import {
+  getCoverImageUrl,
   pickTranslation,
   useBlog,
   type Lang,
@@ -185,6 +186,15 @@ const { data, error } = await useAsyncData<{
 
 const translation = computed<PostTranslation | undefined>(() =>
   data.value?.post ? pickTranslation(data.value.post, props.lang) : undefined,
+)
+
+// Resolved cover: the translation's own art when present, else the
+// post-level fallback. Drives the <img>, og:image, LCP preload and
+// JSON-LD so every surface stays consistent per language.
+const coverImageUrl = computed<string | undefined>(() =>
+  data.value?.post
+    ? getCoverImageUrl(data.value.post, translation.value)
+    : undefined,
 )
 
 // Author display: snapshotted at publish-time on the API side
@@ -276,7 +286,7 @@ useSeoMeta({
   ogTitle: () => translation.value?.title || '',
   ogDescription: () =>
     translation.value?.seo_description || translation.value?.excerpt || '',
-  ogImage: () => data.value?.post?.cover_image_url || undefined,
+  ogImage: () => coverImageUrl.value || undefined,
   ogUrl: () => canonicalUrl.value,
   ogType: 'article',
   twitterCard: 'summary_large_image',
@@ -303,7 +313,7 @@ useHead({
     // Preload the LCP image as soon as the HTML lands so the
     // browser starts the fetch before discovering the <NuxtPicture>
     // markup. Cuts hundreds of ms off LCP on slow connections.
-    const cover = data.value?.post?.cover_image_url
+    const cover = coverImageUrl.value
     if (cover) {
       links.push({
         rel: 'preload',
@@ -357,7 +367,7 @@ useHead({
           '@type': 'BlogPosting',
           headline: t.title,
           description: t.seo_description || t.excerpt || '',
-          image: post.cover_image_url || undefined,
+          image: coverImageUrl.value || undefined,
           datePublished: post.published_at,
           dateModified: post.updated_at,
           inLanguage: props.lang,

--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -6,8 +6,8 @@
     <!-- Cover -->
     <div class="aspect-[16/9] bg-[var(--bg-tertiary)] overflow-hidden">
       <img
-        v-if="post.cover_image_url"
-        :src="post.cover_image_url"
+        v-if="coverImageUrl"
+        :src="coverImageUrl"
         :alt="title"
         width="800"
         height="450"
@@ -70,7 +70,12 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { pickTranslation, type BlogPost, type Lang } from '~/composables/useBlog'
+import {
+  getCoverImageUrl,
+  pickTranslation,
+  type BlogPost,
+  type Lang,
+} from '~/composables/useBlog'
 
 const props = defineProps<{
   post: BlogPost
@@ -80,6 +85,11 @@ const props = defineProps<{
 const lang = computed<Lang>(() => props.lang ?? 'pt-BR')
 
 const translation = computed(() => pickTranslation(props.post, lang.value))
+
+// Per-language cover with post-level fallback (same rule as the article).
+const coverImageUrl = computed(() =>
+  getCoverImageUrl(props.post, translation.value),
+)
 
 const title = computed(() => translation.value?.title ?? '—')
 const excerpt = computed(() => translation.value?.excerpt ?? '')

--- a/composables/useBlog.ts
+++ b/composables/useBlog.ts
@@ -17,6 +17,12 @@ export interface PostTranslation {
   title: string
   excerpt?: string
   content_md: string
+  /**
+   * Per-language cover. When empty the post-level `cover_image_url` is
+   * used instead — see {@link getCoverImageUrl}. Lets the pt/en art stay
+   * coherent (e.g. a title baked into the image).
+   */
+  cover_image_url?: string
   seo_title?: string
   seo_description?: string
   created_at?: string
@@ -189,6 +195,18 @@ export function pickTranslation(
   return (
     post.translations.find((t) => t.lang === lang) ?? post.translations[0]
   )
+}
+
+/**
+ * Resolve the cover image to render: the translation's own cover when it
+ * has one, otherwise the shared post-level cover (the fallback that keeps
+ * existing posts rendering unchanged).
+ */
+export function getCoverImageUrl(
+  post: BlogPost,
+  translation: PostTranslation | undefined,
+): string | undefined {
+  return translation?.cover_image_url || post.cover_image_url
 }
 
 /** Tag name in the requested language, falling back to the slug. */


### PR DESCRIPTION
## Contexto
Renderizar a capa do blog por idioma (pt-BR / en), com fallback para a capa do post. As capas agora chegam já normalizadas em 16:9 da API, então \`object-cover\` não corta mais.

## Mudanças
- \`getCoverImageUrl(post, translation)\`: usa a capa da tradução; se vazia, a do post.
- \`BlogArticle.vue\`: capa resolvida no \`<img>\`, \`og:image\`, preload LCP e JSON-LD.
- \`BlogCard.vue\`: idem no card.
- \`cover_image_url\` adicionado à interface \`PostTranslation\`.

## Teste
- \`vue-tsc --noEmit\`: 0 erros ✅
- Manual: \`/blog/<slug>\` e \`/en/blog/<slug>\` mostram cada um sua capa; post só com padrão mostra a mesma nos dois; capa não corta no artigo nem no card.

## Notas
- Os 5 avisos de \`require-await\` no \`useBlog.ts\` são pré-existentes, em métodos não tocados por este PR.